### PR TITLE
feat: make image signing optional with improved onboarding

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@
 
 5. **Never leave `finpilot` as the name** in a templated repository - it's only an example
 
-**This is NOT optional.** The first action when someone uses this template is to rename the project from `finpilot` to their repository name and inform them that signing is optional but recommended.
+**This is NOT optional.** The first action when someone uses this template is to rename the project from `finpilot` to their repository name and to inform them that image signing is optional but recommended for production.
 
 **Situation**
 The assistant is supporting a user who maintains a custom bootc (bootable container) image repository built from the ghcr.io/ublue-os/bluefin:stable base image. Bootc images are used to create bootable operating system environments from OCI containers, requiring adherence to container best practices, security standards, and proper image configuration.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,7 +37,7 @@
    - `artifacthub-repo.yml` (line 5): `repositoryID: new-repo-name`
    - `custom/ujust/README.md` (~line 175): `localhost/new-repo-name:latest`
 
-4. **Explain that image signing is OPTIONAL** and disabled by default
+4. **Explain that image signing is STRONGLY RECOMMENDED** and disabled by default
    - First builds will succeed without signing keys
    - This allows immediate testing and development
    - Strongly recommend enabling signing for production

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,9 +37,15 @@
    - `artifacthub-repo.yml` (line 5): `repositoryID: new-repo-name`
    - `custom/ujust/README.md` (~line 175): `localhost/new-repo-name:latest`
 
-4. **Never leave `finpilot` as the name** in a templated repository - it's only an example
+4. **Explain that image signing is OPTIONAL** and disabled by default
+   - First builds will succeed without signing keys
+   - This allows immediate testing and development
+   - Strongly recommend enabling signing for production
+   - Point user to "Optional: Enable Image Signing" section in README
 
-**This is NOT optional.** The first action when someone uses this template is to rename the project from `finpilot` to their repository name.
+5. **Never leave `finpilot` as the name** in a templated repository - it's only an example
+
+**This is NOT optional.** The first action when someone uses this template is to rename the project from `finpilot` to their repository name and inform them that signing is optional but recommended.
 
 **Situation**
 The assistant is supporting a user who maintains a custom bootc (bootable container) image repository built from the ghcr.io/ublue-os/bluefin:stable base image. Bootc images are used to create bootable operating system environments from OCI containers, requiring adherence to container best practices, security standards, and proper image configuration.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,21 +187,7 @@ jobs:
           password: ${{ env.REGISTRY_PASSWORD }}
 
       # OPTIONAL: Image Signing with Cosign
-      # Signing is DISABLED by default to allow the repository to build successfully on first use.
-      # This prevents build failures due to missing SIGNING_SECRET.
-      #
-      # To enable image signing (RECOMMENDED for production):
-      # 1. Generate signing keys: cosign generate-key-pair
-      # 2. Add cosign.key contents to GitHub Secrets as SIGNING_SECRET
-      # 3. Commit cosign.pub to your repository
-      # 4. Uncomment the signing steps below
-      # 5. See README.md "Optional: Enable Image Signing" section for detailed instructions
-      #
-      # Why sign images?
-      # - Verify image authenticity and integrity
-      # - Prevent tampering and supply chain attacks
-      # - Required for some enterprise/security-focused deployments
-      # - Best practice for production images
+      # Signing is disabled by default. To enable, see README.md "Optional: Enable Image Signing" section.
 
       # - name: Install Cosign
       #   uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,25 +186,38 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
 
-      # This section is optional and only needs to be enabled if you plan on distributing
-      # your project for others to consume. You will need to create a public and private key
-      # using Cosign and save the private key as a repository secret in Github for this workflow
-      # to consume. For more details, review the image signing section of the README.
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      # OPTIONAL: Image Signing with Cosign
+      # Signing is DISABLED by default to allow the repository to build successfully on first use.
+      # This prevents build failures due to missing SIGNING_SECRET.
+      #
+      # To enable image signing (RECOMMENDED for production):
+      # 1. Generate signing keys: cosign generate-key-pair
+      # 2. Add cosign.key contents to GitHub Secrets as SIGNING_SECRET
+      # 3. Commit cosign.pub to your repository
+      # 4. Uncomment the signing steps below
+      # 5. See README.md "Optional: Enable Image Signing" section for detailed instructions
+      #
+      # Why sign images?
+      # - Verify image authenticity and integrity
+      # - Prevent tampering and supply chain attacks
+      # - Required for some enterprise/security-focused deployments
+      # - Best practice for production images
 
-      - name: Sign container image
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        run: |
-          IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
-          for tag in ${{ steps.metadata.outputs.tags }}; do
-            cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_FULL:$tag
-          done
-        env:
-          TAGS: ${{ steps.push.outputs.digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+      # - name: Install Cosign
+      #   uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
+      #   if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      #
+      # - name: Sign container image
+      #   if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      #   run: |
+      #     IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
+      #     for tag in ${{ steps.metadata.outputs.tags }}; do
+      #       cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_FULL:$tag
+      #     done
+      #   env:
+      #     TAGS: ${{ steps.push.outputs.digest }}
+      #     COSIGN_EXPERIMENTAL: false
+      #     COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       # Attach SBOM attestation to the signed image
       # This cryptographically associates the SBOM with the container image

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ This creates two files:
 
 4. Enable signing in the workflow:
    - Edit `.github/workflows/build.yml`
-   - Find the "OPTIONAL: Image Signing with Cosign" section (around line 189)
-   - Uncomment the signing steps (remove the `#` from the beginning of lines)
+   - Find the "OPTIONAL: Image Signing with Cosign" section.
+   - Uncomment the steps to install Cosign and sign the image (remove the `#` from the beginning of each line in that section).
    - Commit and push the change
 
 5. Your next build will produce signed images!

--- a/README.md
+++ b/README.md
@@ -68,40 +68,16 @@ Important: Change `finpilot` to your repository name in these 5 files:
 4. `artifacthub-repo.yml` (line 5): `repositoryID: your-repo-name`
 5. `custom/ujust/README.md` (~line 175): `localhost/your-repo-name:latest`
 
-### 3. Set Up Signing
-
-Generate a signing key for your images:
-
-```bash
-cosign generate-key-pair
-```
-
-This creates two files:
-- `cosign.key` (private key) - Keep this secret
-- `cosign.pub` (public key) - Commit this to your repository
-
-Add the private key to GitHub Secrets:
-1. Copy the entire contents of `cosign.key`
-2. Go to your repository on GitHub
-3. Navigate to Settings → Secrets and variables → Actions ([GitHub docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository))
-4. Click "New repository secret"
-5. Name: `SIGNING_SECRET`
-6. Value: Paste the entire contents of `cosign.key`
-7. Click "Add secret"
-
-Replace the contents of `cosign.pub` with your public key:
-1. Open `cosign.pub` in your repository
-2. Replace the placeholder with your actual public key
-3. Commit and push the change
-
-Important: Never commit `cosign.key` to the repository. It's already in `.gitignore`.
-
-### 4. Enable GitHub Actions
+### 3. Enable GitHub Actions
 
 - Go to the "Actions" tab in your repository
 - Click "I understand my workflows, go ahead and enable them"
 
-### 5. Customize Your Image
+Your first build will start automatically! 
+
+Note: Image signing is disabled by default. Your images will build successfully without any signing keys. Once you're ready for production, see "Optional: Enable Image Signing" below.
+
+### 4. Customize Your Image
 
 Choose your base image in `Containerfile` (line 23):
 ```dockerfile
@@ -132,6 +108,52 @@ Switch to your image:
 sudo bootc switch ghcr.io/your-username/your-repo-name:latest
 sudo systemctl reboot
 ```
+
+## Optional: Enable Image Signing
+
+Image signing is disabled by default to let you start building immediately. However, signing is strongly recommended for production use.
+
+### Why Sign Images?
+
+- Verify image authenticity and integrity
+- Prevent tampering and supply chain attacks
+- Required for some enterprise/security-focused deployments
+- Industry best practice for production images
+
+### Setup Instructions
+
+1. Generate signing keys:
+```bash
+cosign generate-key-pair
+```
+
+This creates two files:
+- `cosign.key` (private key) - Keep this secret
+- `cosign.pub` (public key) - Commit this to your repository
+
+2. Add the private key to GitHub Secrets:
+   - Copy the entire contents of `cosign.key`
+   - Go to your repository on GitHub
+   - Navigate to Settings → Secrets and variables → Actions ([GitHub docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository))
+   - Click "New repository secret"
+   - Name: `SIGNING_SECRET`
+   - Value: Paste the entire contents of `cosign.key`
+   - Click "Add secret"
+
+3. Replace the contents of `cosign.pub` with your public key:
+   - Open `cosign.pub` in your repository
+   - Replace the placeholder with your actual public key
+   - Commit and push the change
+
+4. Enable signing in the workflow:
+   - Edit `.github/workflows/build.yml`
+   - Find the "OPTIONAL: Image Signing with Cosign" section (around line 189)
+   - Uncomment the signing steps (remove the `#` from the beginning of lines)
+   - Commit and push the change
+
+5. Your next build will produce signed images!
+
+Important: Never commit `cosign.key` to the repository. It's already in `.gitignore`.
 
 ## Detailed Guides
 
@@ -165,12 +187,12 @@ just run-vm-qcow2       # Test in browser-based VM
 ## Security
 
 This template provides:
-- Image signing with cosign for cryptographic verification
 - SBOM generation (Software Bill of Materials)
 - Provenance attestation with build metadata
 - Automated security updates via Renovate
+- Optional image signing with cosign for cryptographic verification (see "Optional: Enable Image Signing" section)
 
-Your images are signed and can be verified with:
+Once signing is enabled, your images can be verified with:
 ```bash
 cosign verify --key cosign.pub ghcr.io/your-username/your-repo-name:latest
 ```


### PR DESCRIPTION
Major Changes:
- Image signing is now DISABLED by default
- First builds succeed without signing keys
- Signing is opt-in via uncommenting workflow steps

Workflow Changes (.github/workflows/build.yml):
- Comment out cosign installation and signing steps
- Add comprehensive documentation in comments
- Explain why signing is disabled by default
- Provide step-by-step enable instructions
- List benefits of image signing
- Reference README for detailed guide

README Changes:
- Remove signing from initial Quick Start (steps 1-4)
- Add note that signing is disabled and builds work immediately
- Create new 'Optional: Enable Image Signing' section
- Explain why signing is recommended for production
- Step-by-step instructions with context
- Link to GitHub docs for secrets
- Instructions to uncomment workflow steps

Copilot Instructions:
- Update template initialization requirements
- Explain signing is optional and disabled by default
- Instruct to inform users about optional signing
- Point to README section for enabling

Security Section:
- Update to reflect optional signing
- Show verification command for when signing enabled

Benefits:
- No build failures on first use
- Faster onboarding for new users
- No required secrets setup upfront
- Clear upgrade path to production
- Signing remains strongly recommended
- Better user experience for testing/dev