### PR TITLE
fix: configure release-please to target testing branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,35 +22,4 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  merge-to-main:
-    runs-on: ubuntu-latest
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-        with:
-          ref: testing
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Merge testing to main
-        run: |
-          git fetch origin main
-          git checkout main
-          git merge --no-ff testing -m "chore: merge release ${{ needs.release-please.outputs.tag_name }} to main"
-          git push origin main
-
-      - name: Trigger Main Branch Build
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: release-merged
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "tag": "${{ needs.release-please.outputs.tag_name }}"}'
+          target-branch: testing


### PR DESCRIPTION
## Summary

Fixes the issue where release-please was creating PRs targeting the main branch while commits were being pushed to the testing branch, causing it to not detect new changes.

## Changes

- Added `target-branch: testing` parameter to release-please action
- Removed automatic merge-to-main job
- Release PRs will now be created within the testing branch

## New Workflow

1. Development happens on testing branch with conventional commits
2. Release-please creates release PR on testing branch
3. Merging the release PR creates a tag/release on testing
4. Testing can be manually merged to main when ready for production

## Why This Fix is Needed

Previously, release-please was configured to run on pushes to `testing` but was looking for commits and creating PRs on `main`. This meant:
- New commits to testing weren't detected
- The release PR remained stale
- Conventional commit messages weren't being picked up

With this fix, release-please properly tracks the testing branch and will create/update PRs with all conventional commits pushed to testing.

## Testing

After merging this PR, push a conventional commit to testing and verify that release-please creates or updates a PR targeting the testing branch.