### PR TITLE
feat: add neovim to Brewfile

### DIFF
--- a/custom/brew/default.Brewfile
+++ b/custom/brew/default.Brewfile
@@ -12,6 +12,7 @@ brew "rg"         # ripgrep - faster grep
 # Development tools
 brew "gh"         # GitHub CLI
 brew "git"        # Git version control
+brew "neovim"     # Hyperextensible Vim-based text editor
 
 # Shell enhancements  
 brew "starship"   # Cross-shell prompt


### PR DESCRIPTION
Adds neovim, a hyperextensible Vim-based text editor, to the default Brewfile for runtime installation via Homebrew.