### PR TITLE
docs: add upstream bootc rechunker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ After building your bootc image, add a rechunk step before pushing to the regist
       -v /var/lib/containers:/var/lib/containers \
       --entrypoint /usr/libexec/bootc-base-imagectl \
       "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
-      rechunk --max-layers 67 \
+      rechunk --max-layers 96 \
       "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
       "localhost/${IMAGE_NAME}:${DEFAULT_TAG}"
 
@@ -248,11 +248,6 @@ Alternative approach using a temporary tag for clarity:
 - The second image reference is the destination (output)
   - When using the same reference for both, the image is rechunked in-place
   - You can also use different tags (e.g., `-rechunked` suffix) and then retag if preferred
-
-**Benefits:**
-- **Smaller updates**: 5-10x reduction in update size by removing replaced files from previous layers
-- **Better resumability**: Evenly sized layers improve download resume capability
-- **Optimized layer distribution**: Files are reorganized for efficient updates
 
 **References:**
 - [CoreOS rpm-ostree build-chunked-oci documentation](https://coreos.github.io/rpm-ostree/build-chunked-oci/)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,73 @@ Ready to take your custom OS to production? Enable these features for enhanced s
     5. Commit and push
   - Status: **Disabled by default** (requires signing first)
 
+- [ ] **Enable Image Rechunking** (Recommended)
+  - Optimizes bootc image layers for better update performance
+  - Reduces update sizes by 5-10x
+  - Improves download resumability with evenly sized layers
+  - To enable:
+    1. Edit `.github/workflows/build.yml`
+    2. Find the "Build Image" step
+    3. Add a rechunk step after the build (see example below)
+  - Status: **Not enabled by default** (optional optimization)
+
+#### Adding Image Rechunking
+
+After building your bootc image, add a rechunk step before pushing to the registry. Here's an example based on the workflow used by [zirconium-dev/zirconium](https://github.com/zirconium-dev/zirconium):
+
+```yaml
+- name: Build image
+  id: build
+  run: sudo podman build -t "${IMAGE_NAME}:${DEFAULT_TAG}" -f ./Containerfile .
+
+- name: Rechunk Image
+  run: |
+    sudo podman run --rm --privileged \
+      -v /var/lib/containers:/var/lib/containers \
+      --entrypoint /usr/libexec/bootc-base-imagectl \
+      "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
+      rechunk --max-layers 67 \
+      "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
+      "localhost/${IMAGE_NAME}:${DEFAULT_TAG}"
+
+- name: Push to Registry
+  run: sudo podman push "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}"
+```
+
+Alternative approach using a temporary tag for clarity:
+
+```yaml
+- name: Rechunk Image
+  run: |
+    sudo podman run --rm --privileged \
+      -v /var/lib/containers:/var/lib/containers \
+      --entrypoint /usr/libexec/bootc-base-imagectl \
+      "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
+      rechunk --max-layers 67 \
+      "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
+      "localhost/${IMAGE_NAME}:${DEFAULT_TAG}-rechunked"
+    
+    # Tag the rechunked image with the original tag
+    sudo podman tag "localhost/${IMAGE_NAME}:${DEFAULT_TAG}-rechunked" "localhost/${IMAGE_NAME}:${DEFAULT_TAG}"
+    sudo podman rmi "localhost/${IMAGE_NAME}:${DEFAULT_TAG}-rechunked"
+```
+
+**Parameters:**
+- `--max-layers`: Maximum number of layers for the rechunked image (typically 67 for optimal balance)
+- The first image reference is the source (input)
+- The second image reference is the destination (output)
+  - When using the same reference for both, the image is rechunked in-place
+  - You can also use different tags (e.g., `-rechunked` suffix) and then retag if preferred
+
+**Benefits:**
+- **Smaller updates**: 5-10x reduction in update size by removing replaced files from previous layers
+- **Better resumability**: Evenly sized layers improve download resume capability
+- **Optimized layer distribution**: Files are reorganized for efficient updates
+
+**References:**
+- [CoreOS rpm-ostree build-chunked-oci documentation](https://coreos.github.io/rpm-ostree/build-chunked-oci/)
+- [bootc documentation](https://containers.github.io/bootc/)
+
 ### After Enabling Production Features
 
 Your workflow will:


### PR DESCRIPTION
Documents the upstream `bootc-base-imagectl rechunk` workflow for bootc images built using the finpilot template.

## Changes

- **New section**: "Enable Image Rechunking" in Production Checklist
- **Two implementation approaches**: in-place rechunking and temporary tag pattern
- **Benefits quantified**: 5-10x update size reduction, improved resumability
- **Integration with workflow**: Added as optional production optimization step

## Example Workflow

Provides detailed examples of adding rechunking to GitHub Actions workflows with both in-place and temporary tag approaches.

References CoreOS rpm-ostree build-chunked-oci and bootc upstream documentation.

Fixes projectbluefin/common#104

Assisted-by: Claude 3.5 Sonnet via GitHub Copilot