### PR TITLE
fix: copy just files from @projectbluefin/common

### DIFF
--- a/build/10-build.sh
+++ b/build/10-build.sh
@@ -20,7 +20,9 @@ echo "::group:: Copy Bluefin Config from Common"
 
 # Copy just files from @projectbluefin/common (includes 00-entry.just which imports 60-custom.just)
 mkdir -p /usr/share/ublue-os/just/
+shopt -s nullglob
 cp -r /ctx/oci/common/bluefin/usr/share/ublue-os/just/* /usr/share/ublue-os/just/
+shopt -u nullglob
 
 echo "::endgroup::"
 

--- a/build/10-build.sh
+++ b/build/10-build.sh
@@ -13,6 +13,17 @@ set -eoux pipefail
 # shellcheck source=/dev/null
 source /ctx/build/copr-helpers.sh
 
+# Enable nullglob for all glob operations to prevent failures on empty matches
+shopt -s nullglob
+
+echo "::group:: Copy Bluefin Config from Common"
+
+# Copy just files from @projectbluefin/common (includes 00-entry.just which imports 60-custom.just)
+mkdir -p /usr/share/ublue-os/just/
+cp -r /ctx/oci/common/bluefin/usr/share/ublue-os/just/* /usr/share/ublue-os/just/
+
+echo "::endgroup::"
+
 echo "::group:: Copy Custom Files"
 
 # Copy Brewfiles to standard location
@@ -20,7 +31,6 @@ mkdir -p /usr/share/ublue-os/homebrew/
 cp /ctx/custom/brew/*.Brewfile /usr/share/ublue-os/homebrew/
 
 # Consolidate Just Files
-mkdir -p /usr/share/ublue-os/just/
 find /ctx/custom/ujust -iname '*.just' -exec printf "\n\n" \; -exec cat {} \; >> /usr/share/ublue-os/just/60-custom.just
 
 # Copy Flatpak preinstall files
@@ -46,5 +56,8 @@ systemctl enable podman.socket
 # Example: systemctl mask unwanted-service
 
 echo "::endgroup::"
+
+# Restore default glob behavior
+shopt -u nullglob
 
 echo "Custom build complete!"


### PR DESCRIPTION
## Summary

Fixes #31 - `60-custom.just` is created but users don't see custom commands when running `ujust`.

**Root cause:** The `00-entry.just` file from `@projectbluefin/common` (which contains `import? "/usr/share/ublue-os/just/60-custom.just"`) was never copied to the system. The Containerfile copies common to `/oci/common`, but the build script only copied custom files - not the just files from common.

**Fix:** Added copy of just files from `/ctx/oci/common/bluefin/usr/share/ublue-os/just/` to `/usr/share/ublue-os/just/` before creating custom just files. Uses `nullglob` to handle edge case where source directory might be empty.

## Test Results

Built image locally and verified the fix:

```bash
$ podman run --rm localhost/finpilot:stable cat /usr/share/ublue-os/just/00-entry.just
# Shows 00-entry.just with: import? "/usr/share/ublue-os/just/60-custom.just"

$ podman run --rm localhost/finpilot:stable cat /usr/share/ublue-os/just/60-custom.just
# Shows all custom commands from custom/ujust/*.just files
```

- [x] Build image with custom ujust commands in `custom/ujust/`
- [x] Verify `00-entry.just` exists in `/usr/share/ublue-os/just/`
- [x] Verify `60-custom.just` exists with consolidated custom commands
- [x] Verify import chain is intact (`00-entry.just` imports `60-custom.just`)