### PR TITLE
fix(ci): add missing -f flag in just validation command

### DIFF
--- a/.github/workflows/validate-justfiles.yml
+++ b/.github/workflows/validate-justfiles.yml
@@ -26,14 +26,14 @@ jobs:
 
           # Validate root Justfile
           echo "::group:: Validating Justfile"
-          just --unstable --fmt --check Justfile
+          just --unstable --fmt --check -f Justfile
           echo "::endgroup::"
 
           # Validate custom ujust files
           find "custom/ujust" -iname '*.just' -print0 | \
             while IFS= read -r -d '' justfile ; do \
               echo "::group:: ===$(basename "$justfile")==="
-              just --unstable --fmt --check "$justfile"
+              just --unstable --fmt --check -f "$justfile"
               echo "::endgroup::"
             done
 


### PR DESCRIPTION
Fixes these CI errors:

```console
error: `--format` used with unexpected argument: `Justfile`
```
```console
error: `--format` used with unexpected argument: `custom-system.just`
```

