### PR TITLE
fix(ci): comply with renovate config migration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
     {
       customType: 'regex',
       description: 'Match container images in Justfile with tag and digest',
-      fileMatch: [
+      managerFilePatterns: [
         '^Justfile$',
       ],
       matchStrings: [
@@ -22,11 +22,11 @@
     {
       customType: 'regex',
       description: 'Match container images in Justfile run_args without tag or digest',
-      fileMatch: [
+      managerFilePatterns: [
         '^Justfile$',
       ],
       matchStrings: [
-        'run_args\\+=\\((?<packageName>[a-zA-Z0-9._:/-]+)\\)',
+        'run_args\\+=\\((?<packageName>[a-zA-Z0-9._:/-]+):?(?<currentValue>\\S+?)\\)',
       ],
       datasourceTemplate: 'docker',
       versioningTemplate: 'docker',


### PR DESCRIPTION
Rename `fileMatch` key to `managerFilePatterns`

---

Unfortunate workaround for `renovate-config-validator` not having a "ignore rule" escape hatch.

The manager in question is intended to match strings without a tag, but the latest renovate requires a capture group for `currentValue`.

I put in a dummy capture group.

Error:
```console
ERROR: Found errors in configuration
       "file": ".github/renovate.json5",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Regex Managers must contain currentValueTemplate configuration or regex group named currentValue"
         }
       ]
```

fixes #43 