### PR TITLE
fix(ci): restore Cosign and SBOM attestation CI examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,3 +174,45 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+
+      # OPTIONAL: Image Signing with Cosign
+      # Signing is disabled by default. To enable, see README.md "Optional: Enable Image Signing" section.
+
+      # - name: Install Cosign
+      #   uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
+      #   if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      #
+      # - name: Sign container image
+      #   if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      #   run: |
+      #     IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
+      #     for tag in ${{ steps.metadata.outputs.tags }}; do
+      #       cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_FULL:$tag
+      #     done
+      #   env:
+      #     TAGS: ${{ steps.push.outputs.digest }}
+      #     COSIGN_EXPERIMENTAL: false
+      #     COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+
+      # OPTIONAL: SBOM Attestation
+      # Attaches SBOM (Software Bill of Materials) to your signed image for supply chain security.
+      # Requires image signing to be enabled first (see above).
+      # To enable:
+      #   1. First enable image signing (see above section)
+      #   2. Uncomment the "Add SBOM Attestation" step below
+      # Documentation: https://slsa.dev/spec/v1.0/requirements#provenance-available
+
+      # - name: Add SBOM Attestation
+      #   if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      #   env:
+      #     IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+      #     DIGEST: ${{ steps.push.outputs.digest }}
+      #     COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+      #     SBOM_OUTPUT: ${{ steps.generate-sbom.outputs.OUTPUT_PATH }}
+      #   run: |
+      #     cd "$(dirname "$SBOM_OUTPUT")"
+      #     cosign attest -y \
+      #       --predicate "$(basename "$SBOM_OUTPUT")" \
+      #       --type spdxjson \
+      #       --key env://COSIGN_PRIVATE_KEY \
+      #       "${IMAGE}@${DIGEST}"


### PR DESCRIPTION
Revert "Restore registry password in build.yml"

This reverts commit 7f7b1a2e04e530dda04b52c6bd9d225edbaba89e to restore the commented-out  cosign and sbom CI config. The commit looks to have been an llm error, because the description refers to an adjacent-but-unaffected code block.

Fixes #40 
