### PR TITLE
fix(ci): Tell renovate the repository to work on

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -28,4 +28,5 @@ jobs:
           configurationFile: .github/renovate.json5
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
           LOG_LEVEL: 'debug'


### PR DESCRIPTION
Fixes issue: #59 

Where the Renovate Action was failing to find any repositories with:
```
WARN: No repositories found - did you want to run with flag --autodiscover?
```

This change uses the builtin Github `github.repository` environment variable to set the current repository as the repo Renovate should scan for dependencies.