### PR TITLE
fix: update bib_image to working sha256 (fixes ISO build)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 export image_name := env("IMAGE_NAME", "finpilot")
 export default_tag := env("DEFAULT_TAG", "stable")
-export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest@sha256:903c01d110b8533f8891f07c69c0ba2377f8d4bc7e963311082b7028c04d529d")
+export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest@sha256:eb2f5db03a3c59e21407579e8cb9a2a9a79af5d103758b6b768b4abbe5b44468")
 
 alias build-vm := build-qcow2
 alias rebuild-vm := rebuild-qcow2


### PR DESCRIPTION
## Summary

Updates the `bib_image` in the Justfile to a newer bootc-image-builder sha256 that has the `grub2.iso` vendor KeyError bug fixed.

## Problem

The current pinned image (`sha256:903c01d...`) causes ISO builds to fail with:

```
KeyError: 'vendor'
```

## Fix

Replace with `sha256:eb2f5db...` which has this bug resolved. Users cloning the template can now run `just build` without manually updating the bib_image reference.

Closes #65

## Test plan

- [ ] `just build` completes without the KeyError
- [ ] ISO image can be built from the updated bib_image