### PR TITLE
docs: fix README base image reference and line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,13 @@ Note: Image signing is disabled by default. Your images will build successfully 
 
 ### 4. Customize Your Image
 
-Choose your base image in `Containerfile` (line 23):
+Choose your base image in `Containerfile` (line 48):
 ```dockerfile
-FROM ghcr.io/ublue-os/bluefin:stable
+FROM ghcr.io/ublue-os/silverblue-main:latest
 ```
+
+Finpilot layers on top of Fedora Silverblue, not Bluefin. Bluefin's desktop
+configuration is provided by `@projectbluefin/common` earlier in the build.
 
 Add your packages in `build/10-build.sh`:
 ```bash


### PR DESCRIPTION
## Summary

Fixes incorrect base image reference in the README.

Closes #53

### Changes
- Correct line number: 23 → 48
- Correct image: `ghcr.io/ublue-os/bluefin:stable` → `ghcr.io/ublue-os/silverblue-main:latest`
- Add clarifying note that finpilot layers on Silverblue, with Bluefin desktop config coming from `@projectbluefin/common`

## Test plan
- [ ] Verify README renders correctly
- [ ] Verify Containerfile line 48 matches the documented base image