### PR TITLE
docs: fix README base image reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Note: Image signing is disabled by default. Your images will build successfully 
 
 ### 4. Customize Your Image
 
-Choose your base image in `Containerfile` (line 23):
+Choose your base image in `Containerfile` (line 48):
 ```dockerfile
-FROM ghcr.io/ublue-os/bluefin:stable
+FROM ghcr.io/ublue-os/silverblue-main:latest
 ```
 
 Add your packages in `build/10-build.sh`:


### PR DESCRIPTION
## Summary

Fixes two errors in the README's "Customize Your Image" section:

1. The Containerfile line number was wrong — the base image  is on **line 48**, not line 23.
2. The example base image was , but the template actually uses .

## Changes

- **`README.md`**: Fix line number (23→48) and example base image (bluefin:stable→silverblue-main:latest).

Closes #53