### PR TITLE
fix(ci): use podman save + syft docker-archive for SBOM (#77)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,9 +146,12 @@ jobs:
       #     DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
       #     SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
       #   run: |
+      #     # Save image to tar so Syft can access it (podman rootless has no socket)
+      #     IMAGE_TAR="$(mktemp -d)/image.tar"
+      #     podman save -o "$IMAGE_TAR" ${IMAGE}:${DEFAULT_TAG}
       #     OUTPUT_PATH="$(mktemp -d)/sbom.json"
       #     export SYFT_PARALLELISM=$(($(nproc)*2))
-      #     $SYFT_CMD ${IMAGE}:${DEFAULT_TAG} -o spdx-json=${OUTPUT_PATH}
+      #     $SYFT_CMD docker-archive:$IMAGE_TAR -o spdx-json=${OUTPUT_PATH}
       #     echo "OUTPUT_PATH=${OUTPUT_PATH}" >> $GITHUB_OUTPUT
 
       # These `if` statements are so that pull requests for your custom images do not make it publish any packages under your name without you knowing


### PR DESCRIPTION
## Summary

Fixes #77 — Syft could not find the container image after build because podman rootless has no socket available for Syft's provider chain.

## Root cause

The old SBOM step ran `syft ${IMAGE}:${DEFAULT_TAG}` which traverses Syft's provider chain (Docker → Podman → containerd → registry) looking for the image. On the CI runner:
- Docker is not available  
- Podman is rootless (no socket / daemon)
- containerd socket requires root
- The image is only in the local registry, not pushed yet

## Fix

Saves the built image to a tar archive with `podman save`, then scans it with `syft docker-archive:$tar`. This works without any daemon/socket access.

## Test plan
- [ ] Uncomment the Setup Syft and Generate SBOM steps
- [ ] Verify the Generate SBOM step produces a valid spdx-json output
- [ ] Verify the Add SBOM Attestation step can find the output