### PR TITLE
fix: prevent clean-stage.sh glob failure on empty /var/cache

### DIFF
--- a/build/clean-stage.sh
+++ b/build/clean-stage.sh
@@ -19,8 +19,11 @@ systemctl mask flatpak-add-fedora-repos.service
 rm -f "${CLEAN_ROOT}/usr/lib/systemd/system/flatpak-add-fedora-repos.service"
 
 rm -rf "${CLEAN_ROOT}/.gitkeep"
-find "${CLEAN_ROOT}/var"/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
-find "${CLEAN_ROOT}/var/cache"/* -maxdepth 0 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
+# Use -mindepth/-maxdepth instead of shell globs so these are no-ops when the
+# directories are empty (e.g. /var/cache/{libdnf5,rpm-ostree} only exist as
+# transient buildah cache mounts and are not present in this layer).
+find "${CLEAN_ROOT}/var" -mindepth 1 -maxdepth 1 -type d \! -name cache -exec rm -fr {} \;
+find "${CLEAN_ROOT}/var/cache" -mindepth 1 -maxdepth 1 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
 
 # Clear tmpfs-backed runtime directories without deleting the directories
 # themselves. Buildah may have bind mounts in these paths during RUN, so


### PR DESCRIPTION
## Problem

When `/var/cache` is empty during a container build—e.g. when `libdnf5` and `rpm-ostree` caches are transient `--mount=type=cache` buildah mount points rather than persisted image layers—the shell glob `"${CLEAN_ROOT}/var/cache"/*` expands to a literal `*`. This causes `find` to fail with `ENOENT`:

```
find: '…/var/cache/*': No such file or directory
```

Because the script runs under `set -e`, this error aborts the entire build.

## Root Cause

`build/10-build.sh` uses `--mount=type=cache` for `/var/cache/libdnf5` and `/var/cache/rpm-ostree`. These mount points are ephemeral and do not persist to the image layer. The `clean-stage.sh` RUN layer therefore sees an empty `/var/cache` directory, which triggers the glob failure.

Upstream builds have avoided this only because their package set happens to leave at least one directory under `/var/cache` (via differing cache remnants), so the glob never fails there. The bug is latent and will trigger for any downstream build whose package set is small enough to leave `/var/cache` empty.

## Fix

Replace `find …/* -maxdepth 0` with `find … -mindepth 1 -maxdepth 1`—the same pattern already used for `tmp`, `boot`, and `run` cleanup earlier in the same script. Empty directories become no-ops instead of fatal errors.

Same fix applied to the sibling `"${CLEAN_ROOT}/var"/*` pattern for consistency.

## Verification

Tested locally by simulating an empty `/var/cache`:
- **Before fix**: `find /tmp/clean_root/var/cache/* …` → `find: '/tmp/clean_root/var/cache/*': No such file or directory` → exit code 1
- **After fix**: `find /tmp/clean_root/var/cache -mindepth 1 …` → exit code 0 (no-op on empty dir)

Also validated with `shellcheck`.

Closes #<!-- leave blank – no issue filed -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary system directories to make stage preparation more reliable.
  * Preserved important cache-related directories while removing only the intended variable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->