### PR TITLE
feat(build): add NVIDIA example and clarify script activation

### DIFF
--- a/.agents/skills/finpilot-build.md
+++ b/.agents/skills/finpilot-build.md
@@ -69,6 +69,19 @@ release, update both the `FEDORA_MAJOR_VERSION` ARG and the base image tag.
 - Always use `dnf5 install -y` (non-interactive)
 - COPR: enable → install → `copr_install_isolated` (auto-disables); never leave a repo enabled
 
+### NVIDIA GPU support
+
+NVIDIA support is a build-time option activated by copying the example script:
+
+```bash
+cp build/20-nvidia.sh.example build/20-nvidia.sh
+just build
+```
+
+All NVIDIA logic is self-contained in `20-nvidia.sh`. When activated, it provisions the NVIDIA driver, CDI container toolkit, Mutter kms-modifiers, and bootc kernel args directly into the base image — no separate image variant, no `IMAGE_NAME` gating.
+
+Deactivate by removing or renaming back to `.example`. See `build/20-nvidia.sh.example` for the full implementation.
+
 ### 00-image-info.sh branding
 
 The comment in the `os-release` append block must use `${IMAGE_NAME}`:

--- a/.agents/skills/finpilot-build.md
+++ b/.agents/skills/finpilot-build.md
@@ -71,16 +71,18 @@ release, update both the `FEDORA_MAJOR_VERSION` ARG and the base image tag.
 
 ### NVIDIA GPU support
 
-NVIDIA support is a build-time option activated by copying the example script:
+NVIDIA support is a build-time option activated by renaming the example script and adding its explicit Containerfile `RUN` block:
 
 ```bash
-cp build/20-nvidia.sh.example build/20-nvidia.sh
+mv build/40-nvidia.sh.example build/40-nvidia.sh
+# Add the standard RUN block for /ctx/build/40-nvidia.sh after 10-build.sh.
+# See build/README.md.
 just build
 ```
 
-All NVIDIA logic is self-contained in `20-nvidia.sh`. When activated, it provisions the NVIDIA driver, CDI container toolkit, Mutter kms-modifiers, and bootc kernel args directly into the base image — no separate image variant, no `IMAGE_NAME` gating.
+All NVIDIA logic is self-contained in `40-nvidia.sh`. When both the script and its explicit Containerfile `RUN` block are activated, it provisions the NVIDIA driver, CDI container toolkit, Mutter kms-modifiers, and bootc kernel args directly into the base image — no separate image variant, no `IMAGE_NAME` gating.
 
-Deactivate by removing or renaming back to `.example`. See `build/20-nvidia.sh.example` for the full implementation.
+Deactivate by removing its Containerfile `RUN` block and renaming the script back to `.example`. See `build/40-nvidia.sh.example` for the full implementation.
 
 ### 00-image-info.sh branding
 

--- a/.agents/skills/finpilot-examples.md
+++ b/.agents/skills/finpilot-examples.md
@@ -27,23 +27,24 @@ metadata:
 
 1. **Find the relevant example** in `build/` directory
 2. **Copy and rename** from `.example` to `.sh`
-3. **Customize** for your specific use case
-4. **Validate** with `shellcheck` and `just build`
-5. **Commit** (via PR to `main`)
+3. **Add its explicit `RUN` block** after `10-build.sh` in `Containerfile`
+4. **Customize** for your specific use case
+5. **Validate** with `shellcheck` and `just build`
+6. **Commit** (via PR to `main`)
 
 ## The Activation Pattern
 
 All example scripts in `build/` follow the pattern:
 
 1. **Inactive**: Named `NN-descriptive-name.sh.example`
-2. **Active**: Rename to `NN-descriptive-name.sh`
-3. **Execution**: Build scripts run in numerical order (`00-`, `10-`, `20-`, `30-`)
+2. **Activate the file**: Rename to `NN-descriptive-name.sh`
+3. **Activate execution**: Add an explicit `RUN` block after `10-build.sh` in `Containerfile`
 
-**Important:** Only `.sh` files are executed during the build. `.example` files are ignored.
+The template does not automatically discover numbered scripts. See `build/README.md` for the standard mounted `RUN` block; replace its script path with the activated example.
 
 ## Existing Example Scripts
 
-### `build/20-nvidia.sh.example`
+### `build/40-nvidia.sh.example`
 
 **What it does:**
 
@@ -56,11 +57,13 @@ All example scripts in `build/` follow the pattern:
 **How to activate:**
 
 ```bash
-cp build/20-nvidia.sh.example build/20-nvidia.sh
+mv build/40-nvidia.sh.example build/40-nvidia.sh
+# Add the standard RUN block for /ctx/build/40-nvidia.sh after 10-build.sh.
+# See build/README.md.
 just build
 ```
 
-All NVIDIA logic is self-contained in the script. When activated (renamed to `.sh`), it provisions NVIDIA support directly into the base image — no separate image variant needed. Deactivate by removing or renaming back to `.example`.
+All NVIDIA logic is self-contained in the script. It provisions NVIDIA support directly into the base image when both the script is renamed to `.sh` and its Containerfile `RUN` block is added. Deactivate by removing that `RUN` block and renaming the file back to `.example`.
 
 **Expected validation:**
 
@@ -82,7 +85,8 @@ All NVIDIA logic is self-contained in the script. When activated (renamed to `.s
 
 ```bash
 cp build/20-onepassword.sh.example build/20-onepassword.sh
-# Edit build/20-onepassword.sh to customize if needed
+# Add the standard RUN block for /ctx/build/20-onepassword.sh after 10-build.sh.
+# See build/README.md, then customize this script if needed.
 ```
 
 **Expected validation:**
@@ -104,7 +108,8 @@ cp build/20-onepassword.sh.example build/20-onepassword.sh
 
 ```bash
 cp build/30-cosmic-desktop.sh.example build/30-cosmic-desktop.sh
-# Edit build/30-cosmic-desktop.sh to customize if needed
+# Add the standard RUN block for /ctx/build/30-cosmic-desktop.sh after 10-build.sh.
+# See build/README.md, then customize this script if needed.
 ```
 
 **Expected validation:**
@@ -130,7 +135,8 @@ When adding a new pattern that others might reuse, create an `.example` file:
 set -euo pipefail
 
 # Description: [What this script does]
-# Activate by: cp build/NN-name.sh.example build/NN-name.sh
+# Activate by: rename this file to build/NN-name.sh, then add its explicit
+# RUN block after 10-build.sh in Containerfile (see build/README.md).
 # Customize: [What to change]
 
 # Example: Add a third-party repository
@@ -146,7 +152,7 @@ set -euo pipefail
 | Third-party repo (`20-*.sh`) | Yes        | Yes        | Verify repo URL accessible              |
 | Desktop swap (`30-*.sh`)     | Yes        | Yes        | Test in VM (`just run-vm-qcow2`)        |
 | COPR install (`20-*.sh`)     | Yes        | Yes        | Verify COPR exists and packages install |
-| NVIDIA GPU (`20-*.sh`)       | Yes        | Yes        | Test on NVIDIA hardware; verify `nvidia-smi` after boot |
+| NVIDIA GPU (`40-nvidia.sh`)  | Yes        | Yes        | Test on NVIDIA hardware; verify `nvidia-smi` after boot |
 
 ## Link to Package Decision Tree
 
@@ -163,12 +169,13 @@ For deciding whether to use an example script or add directly to `build/10-build
 | Rationalization                                              | Reality                                                                                                  |
 | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
 | "I'll just add my script directly — no need for an example." | If the pattern is reusable, an example helps future contributors. If it's one-off, add to `10-build.sh`. |
-| "I'll leave it as `.example` and never rename it."           | `.example` files are ignored in the build. They must be renamed to `.sh` to have any effect.             |
-| "I modified the `.example` file — that should be enough."    | The build only runs `.sh` files. Modify the `.example`, then rename to `.sh`.                            |
+| "I'll leave it as `.example` and never rename it."           | `.example` files are inactive. Rename one to `.sh` and add its explicit Containerfile `RUN` block.       |
+| "I renamed the example, so it will run."                      | The template runs only scripts explicitly named in Containerfile. Add the matching `RUN` block.           |
 
 ## Red Flags
 
 - `.example` file modified but not renamed to `.sh`
+- Renamed `.sh` file without a matching Containerfile `RUN` block
 - New `.sh` file without `set -euo pipefail`
 - Script using `dnf` or `yum` instead of `dnf5`
 - COPR repo not disabled after install
@@ -178,6 +185,7 @@ For deciding whether to use an example script or add directly to `build/10-build
 ## Verification
 
 - [ ] Did you rename the `.example` file to `.sh`?
+- [ ] Did you add its `RUN` block after `10-build.sh` in Containerfile?
 - [ ] Did you run `shellcheck` on the new `.sh` file?
 - [ ] Did the build succeed with `just build`?
 - [ ] For desktop swaps: did you test in a VM (`just run-vm-qcow2`)?

--- a/.agents/skills/finpilot-examples.md
+++ b/.agents/skills/finpilot-examples.md
@@ -43,6 +43,33 @@ All example scripts in `build/` follow the pattern:
 
 ## Existing Example Scripts
 
+### `build/20-nvidia.sh.example`
+
+**What it does:**
+
+- Pulls pre-built NVIDIA akmods from `ghcr.io/ublue-os/akmods-nvidia-open`
+- Installs NVIDIA driver (open kernel modules, CUDA, libnvidia-container)
+- Configures CDI (Container Device Interface) GPU passthrough for Podman
+- Writes bootc kernel args: nouveau blacklist + `nvidia-drm.modeset=1`
+- Enables Mutter `kms-modifiers` for Wayland support on NVIDIA
+
+**How to activate:**
+
+```bash
+cp build/20-nvidia.sh.example build/20-nvidia.sh
+just build
+```
+
+All NVIDIA logic is self-contained in the script. When activated (renamed to `.sh`), it provisions NVIDIA support directly into the base image — no separate image variant needed. Deactivate by removing or renaming back to `.example`.
+
+**Expected validation:**
+
+- `pr-validation.yml` → shellcheck
+- `build-image.yml` → full build test
+- **Must test on actual NVIDIA hardware** — Wayland/modeset issues are not caught in CI
+
+---
+
 ### `build/20-onepassword.sh.example`
 
 **What it does:**
@@ -119,6 +146,7 @@ set -euo pipefail
 | Third-party repo (`20-*.sh`) | Yes        | Yes        | Verify repo URL accessible              |
 | Desktop swap (`30-*.sh`)     | Yes        | Yes        | Test in VM (`just run-vm-qcow2`)        |
 | COPR install (`20-*.sh`)     | Yes        | Yes        | Verify COPR exists and packages install |
+| NVIDIA GPU (`20-*.sh`)       | Yes        | Yes        | Test on NVIDIA hardware; verify `nvidia-smi` after boot |
 
 ## Link to Package Decision Tree
 

--- a/.agents/skills/finpilot-packages.md
+++ b/.agents/skills/finpilot-packages.md
@@ -45,7 +45,7 @@ metadata:
 | Replace desktop environment    | Remove old → install new → set default        | `build/30-*.sh` (see examples)       |
 | Switch base image              | Update `FROM` line                            | `Containerfile`                      |
 | Add OCI containers             | Uncomment/add `COPY --from=`                  | `Containerfile` ctx stage            |
-| Add NVIDIA GPU support         | Activate `20-nvidia.sh.example` (`cp build/20-nvidia.sh.example build/20-nvidia.sh`) | `build/20-nvidia.sh` |
+| Add NVIDIA GPU support         | Rename `40-nvidia.sh.example`, then add its RUN block after `10-build.sh` | `build/40-nvidia.sh` |
 
 ## Build-Time: `build/10-build.sh`
 

--- a/.agents/skills/finpilot-packages.md
+++ b/.agents/skills/finpilot-packages.md
@@ -45,6 +45,7 @@ metadata:
 | Replace desktop environment    | Remove old → install new → set default        | `build/30-*.sh` (see examples)       |
 | Switch base image              | Update `FROM` line                            | `Containerfile`                      |
 | Add OCI containers             | Uncomment/add `COPY --from=`                  | `Containerfile` ctx stage            |
+| Add NVIDIA GPU support         | Activate `20-nvidia.sh.example` (`cp build/20-nvidia.sh.example build/20-nvidia.sh`) | `build/20-nvidia.sh` |
 
 ## Build-Time: `build/10-build.sh`
 

--- a/.agents/skills/finpilot-troubleshooting.md
+++ b/.agents/skills/finpilot-troubleshooting.md
@@ -57,6 +57,7 @@ metadata:
 | Podman GPU passthrough not working         | CDI not configured or `nvidia-container-toolkit` missing | Verify `nvidia-container-toolkit-base` is installed; check `nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place` ran |
 | `nouveau_icd` conflicts with NVIDIA driver | Nouveau Vulkan ICD not removed                     | Add `rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json` in the NVIDIA script                           |
 | Container fails with "device not found"    | NVIDIA kernel module not loaded                    | Reboot after switching to NVIDIA image; verify `lsmod \| grep nvidia`; check kernel arg blacklist isn't too aggressive |
+
 ## CI Failures
 
 | Symptom                                    | Cause                                              | Solution                                                                  |

--- a/.agents/skills/finpilot-troubleshooting.md
+++ b/.agents/skills/finpilot-troubleshooting.md
@@ -56,8 +56,7 @@ metadata:
 | Wayland broken on NVIDIA                   | Missing `nvidia-drm.modeset=1` or `kms-modifiers`  | Confirm `/usr/lib/bootc/kargs.d/00-nvidia.toml` exists with modeset karg; verify `kms-modifiers` was added to Mutter gschema override |
 | Podman GPU passthrough not working         | CDI not configured or `nvidia-container-toolkit` missing | Verify `nvidia-container-toolkit-base` is installed; check `nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place` ran |
 | `nouveau_icd` conflicts with NVIDIA driver | Nouveau Vulkan ICD not removed                     | Add `rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json` in the NVIDIA script                           |
-| Container fails with "device not found"    | NVIDIA kernel module not loaded                    | Reboot after switching to NVIDIA image; verify `lsmod | grep nvidia`; check kernel arg blacklist isn't too aggressive |
-
+| Container fails with "device not found"    | NVIDIA kernel module not loaded                    | Reboot after switching to NVIDIA image; verify `lsmod \| grep nvidia`; check kernel arg blacklist isn't too aggressive |
 ## CI Failures
 
 | Symptom                                    | Cause                                              | Solution                                                                  |

--- a/.agents/skills/finpilot-troubleshooting.md
+++ b/.agents/skills/finpilot-troubleshooting.md
@@ -46,6 +46,18 @@ metadata:
 | Multi-stage build fails at `ctx` stage | Missing `COPY --from=` or invalid OCI image reference                        | Verify OCI image names and digests in `Containerfile` ctx stage                             |
 | `just build` fails immediately         | `just` not installed or `Justfile` syntax error                              | Run `just --list`, check `Justfile` for syntax errors                                       |
 
+## NVIDIA-Specific Issues
+
+| Symptom                                    | Cause                                              | Solution                                                                                               |
+| ------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `nvidia-smi` not found after boot          | NVIDIA driver not installed during build           | Verify `20-nvidia.sh` is activated (not `.example`) — rename from `.example` to `.sh` and rebuild  |
+| NVIDIA build fails: "Signing key not found" | ublue-os/staging COPR GPG key not imported         | Add `rpm --import https://download.copr.fedorainfracloud.org/results/ublue-os/staging/pubkey.gpg` before `nvidia-install.sh` |
+| NVIDIA build fails: akmods pull fails      | Wrong `AKMODS_FLAVOR` or kernel version mismatch   | Verify `AKMODS_FLAVOR` matches your base image (`main` for stock Fedora, `coreos-stable` for bluefin kernel); check kernel version with `rpm -q kernel-core` |
+| Wayland broken on NVIDIA                   | Missing `nvidia-drm.modeset=1` or `kms-modifiers`  | Confirm `/usr/lib/bootc/kargs.d/00-nvidia.toml` exists with modeset karg; verify `kms-modifiers` was added to Mutter gschema override |
+| Podman GPU passthrough not working         | CDI not configured or `nvidia-container-toolkit` missing | Verify `nvidia-container-toolkit-base` is installed; check `nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place` ran |
+| `nouveau_icd` conflicts with NVIDIA driver | Nouveau Vulkan ICD not removed                     | Add `rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json` in the NVIDIA script                           |
+| Container fails with "device not found"    | NVIDIA kernel module not loaded                    | Reboot after switching to NVIDIA image; verify `lsmod | grep nvidia`; check kernel arg blacklist isn't too aggressive |
+
 ## CI Failures
 
 | Symptom                                    | Cause                                              | Solution                                                                  |

--- a/.agents/skills/finpilot-troubleshooting.md
+++ b/.agents/skills/finpilot-troubleshooting.md
@@ -50,7 +50,7 @@ metadata:
 
 | Symptom                                    | Cause                                              | Solution                                                                                               |
 | ------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `nvidia-smi` not found after boot          | NVIDIA driver not installed during build           | Verify `20-nvidia.sh` is activated (not `.example`) — rename from `.example` to `.sh` and rebuild  |
+| `nvidia-smi` not found after boot          | NVIDIA driver was not installed during build       | Rename `40-nvidia.sh.example` to `.sh`, add its RUN block after `10-build.sh`, and rebuild |
 | NVIDIA build fails: "Signing key not found" | ublue-os/staging COPR GPG key not imported         | Add `rpm --import https://download.copr.fedorainfracloud.org/results/ublue-os/staging/pubkey.gpg` before `nvidia-install.sh` |
 | NVIDIA build fails: akmods pull fails      | Wrong `AKMODS_FLAVOR` or kernel version mismatch   | Verify `AKMODS_FLAVOR` matches your base image (`main` for stock Fedora, `coreos-stable` for bluefin kernel); check kernel version with `rpm -q kernel-core` |
 | Wayland broken on NVIDIA                   | Missing `nvidia-drm.modeset=1` or `kms-modifiers`  | Confirm `/usr/lib/bootc/kargs.d/00-nvidia.toml` exists with modeset karg; verify `kms-modifiers` was added to Mutter gschema override |

--- a/build/20-onepassword.sh.example
+++ b/build/20-onepassword.sh.example
@@ -11,7 +11,8 @@ set -euo pipefail
 #
 # To use this script:
 # 1. Rename this file to remove the .example extension: 20-onepassword.sh
-# 2. The build system will automatically run scripts in numerical order
+# 2. Add an explicit RUN block for /ctx/build/20-onepassword.sh after
+#    10-build.sh in Containerfile. See build/README.md for the standard block.
 #
 # IMPORTANT CONVENTIONS (from @ublue-os/bluefin):
 # - Always clean up temporary repository files after installation

--- a/build/30-cosmic-desktop.sh.example
+++ b/build/30-cosmic-desktop.sh.example
@@ -13,7 +13,8 @@ set -euo pipefail
 #
 # To use this script:
 # 1. Rename to remove .example extension: mv 30-cosmic-desktop.sh.example 30-cosmic-desktop.sh
-# 2. Build - scripts run in numerical order automatically
+# 2. Add an explicit RUN block for /ctx/build/30-cosmic-desktop.sh after
+#    10-build.sh in Containerfile. See build/README.md for the standard block.
 #
 # WARNING: This removes GNOME and replaces it with COSMIC. Only use this if
 # you want COSMIC as your desktop environment instead of GNOME.

--- a/build/40-nvidia.sh.example
+++ b/build/40-nvidia.sh.example
@@ -2,11 +2,14 @@
 set -euo pipefail
 
 # Description: NVIDIA GPU driver and container toolkit setup (example)
-# Activate by: cp build/20-nvidia.sh.example build/20-nvidia.sh
+# Activate by:
+#   1. mv build/40-nvidia.sh.example build/40-nvidia.sh
+#   2. Add an explicit RUN block for /ctx/build/40-nvidia.sh after 10-build.sh
+#      in Containerfile. See build/README.md for the standard block.
 #
 # This script provisions NVIDIA GPU support directly into the base image.
-# When activated (renamed to .sh), it runs on every build.
-# Deactivate by removing or renaming back to .example.
+# Deactivate by removing its Containerfile RUN block and renaming it back to
+# .example.
 
 echo "::group:: ===$(basename "$0")==="
 
@@ -33,8 +36,10 @@ skopeo copy --retry-times 3 \
     "docker://ghcr.io/ublue-os/akmods-nvidia-open:${AKMODS_FLAVOR}-$(rpm -E %fedora)-${KERNEL}" \
     dir:/tmp/akmods-rpms
 
-NVIDIA_TARGZ=$(jq -r '.layers[0].digest' /tmp/akmods-rpms/manifest.json | cut -d : -f 2)
-tar -xvzf "/tmp/akmods-rpms/${NVIDIA_TARGZ}" -C /tmp/
+mapfile -t NVIDIA_TARGZS < <(jq -r '.layers[].digest' /tmp/akmods-rpms/manifest.json | cut -d : -f 2)
+for nvidia_targz in "${NVIDIA_TARGZS[@]}"; do
+    tar -xvf "/tmp/akmods-rpms/${nvidia_targz}" -C /tmp/
+done
 mv /tmp/rpms/* /tmp/akmods-rpms/
 
 # -----------------------------------------------------------------------

--- a/build/40-nvidia.sh.example
+++ b/build/40-nvidia.sh.example
@@ -19,7 +19,7 @@ echo "::group:: ===$(basename "$0")==="
 # For stock Fedora kernels (silverblue), use flavor "main".
 # For custom kernels (bluefin-style), override AKMODS_FLAVOR via ARG.
 AKMODS_FLAVOR="${AKMODS_FLAVOR:-main}"
-KERNEL="${KERNEL:-$(rpm -q kernel-core --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}' 2>/dev/null)}"
+KERNEL="${KERNEL:-$(rpm -q kernel-core --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}' 2>/dev/null || true)}"
 
 if [[ -z "${KERNEL}" ]]; then
     echo "ERROR: Could not determine kernel version"

--- a/build/40-nvidia.sh.example
+++ b/build/40-nvidia.sh.example
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Description: NVIDIA GPU driver and container toolkit setup (example)
+# Activate by: cp build/20-nvidia.sh.example build/20-nvidia.sh
+#
+# This script provisions NVIDIA GPU support directly into the base image.
+# When activated (renamed to .sh), it runs on every build.
+# Deactivate by removing or renaming back to .example.
+
+echo "::group:: ===$(basename "$0")==="
+
+# -----------------------------------------------------------------------
+# 1. Determine kernel version and akmods flavor
+# -----------------------------------------------------------------------
+# For stock Fedora kernels (silverblue), use flavor "main".
+# For custom kernels (bluefin-style), override AKMODS_FLAVOR via ARG.
+AKMODS_FLAVOR="${AKMODS_FLAVOR:-main}"
+KERNEL="${KERNEL:-$(rpm -q kernel-core --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}' 2>/dev/null)}"
+
+if [[ -z "${KERNEL}" ]]; then
+    echo "ERROR: Could not determine kernel version"
+    exit 1
+fi
+
+echo "Using kernel: ${KERNEL} (flavor: ${AKMODS_FLAVOR})"
+
+# -----------------------------------------------------------------------
+# 2. Pull pre-built NVIDIA akmods from ublue-os OCI artifact
+# -----------------------------------------------------------------------
+mkdir -p /tmp/akmods-rpms
+skopeo copy --retry-times 3 \
+    "docker://ghcr.io/ublue-os/akmods-nvidia-open:${AKMODS_FLAVOR}-$(rpm -E %fedora)-${KERNEL}" \
+    dir:/tmp/akmods-rpms
+
+NVIDIA_TARGZ=$(jq -r '.layers[0].digest' /tmp/akmods-rpms/manifest.json | cut -d : -f 2)
+tar -xvzf "/tmp/akmods-rpms/${NVIDIA_TARGZ}" -C /tmp/
+mv /tmp/rpms/* /tmp/akmods-rpms/
+
+# -----------------------------------------------------------------------
+# 3. Exclude Go NVIDIA Container Toolkit from Fedora repo (avoid conflicts)
+# -----------------------------------------------------------------------
+dnf5 config-manager setopt excludepkgs=golang-github-nvidia-container-toolkit
+
+# -----------------------------------------------------------------------
+# 4. Pre-import COPR GPG key and run nvidia-install.sh from the artifact
+# -----------------------------------------------------------------------
+rpm --import "https://download.copr.fedorainfracloud.org/results/ublue-os/staging/pubkey.gpg"
+IMAGE_NAME="${BASE_IMAGE_NAME}" \
+    AKMODNV_PATH="/tmp/akmods-rpms" \
+    MULTILIB=0 \
+    /tmp/akmods-rpms/ublue-os/nvidia-install.sh
+
+# -----------------------------------------------------------------------
+# 5. Remove nouveau Vulkan ICD (prevents conflicts with nvidia driver)
+# -----------------------------------------------------------------------
+rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json
+
+# -----------------------------------------------------------------------
+# 6. Symlink nvidia-ml (needed by some container runtimes)
+# -----------------------------------------------------------------------
+ln -sf libnvidia-ml.so.1 /usr/lib64/libnvidia-ml.so
+
+# -----------------------------------------------------------------------
+# 7. Write bootc kernel args: blacklist nouveau, enable nvidia-drm modeset
+# -----------------------------------------------------------------------
+tee /usr/lib/bootc/kargs.d/00-nvidia.toml <<EOF
+kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1", "initcall_blacklist=simpledrm_platform_driver_init"]
+EOF
+
+# -----------------------------------------------------------------------
+# 8. Enable Mutter kms-modifiers for NVIDIA Wayland support
+# -----------------------------------------------------------------------
+# Required for correct Wayland rendering on NVIDIA hardware.
+if [[ -f /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override ]]; then
+    sed -i "/experimental-features/ s/\]/, 'kms-modifiers'&/" \
+        /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+fi
+
+# -----------------------------------------------------------------------
+# 9. Install NVIDIA Container Toolkit (CDI-based, for Podman passthrough)
+# -----------------------------------------------------------------------
+# Uses the official C toolkit (nvidia-container-toolkit-base), NOT the
+# Fedora Go-based toolkit. CDI (Container Device Interface) is the correct
+# approach for bootc/rootless containers — no legacy OCI hooks.
+curl -fsSL https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
+    | tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+dnf5 -y install nvidia-container-toolkit-base
+nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place
+rm -f /etc/yum.repos.d/nvidia-container-toolkit.repo
+
+# -----------------------------------------------------------------------
+# 10. Verify critical NVIDIA packages are installed
+# -----------------------------------------------------------------------
+NV_PACKAGES=(
+    libnvidia-container-tools
+    kmod-nvidia
+    nvidia-driver-cuda
+)
+for pkg in "${NV_PACKAGES[@]}"; do
+    rpm -q "${pkg}" >/dev/null || {
+        echo "ERROR: Missing NVIDIA package: ${pkg}"
+        exit 1
+    }
+done
+
+echo "NVIDIA setup complete"
+echo "::endgroup::"

--- a/build/40-nvidia.sh.example
+++ b/build/40-nvidia.sh.example
@@ -32,6 +32,7 @@ echo "Using kernel: ${KERNEL} (flavor: ${AKMODS_FLAVOR})"
 # 2. Pull pre-built NVIDIA akmods from ublue-os OCI artifact
 # -----------------------------------------------------------------------
 mkdir -p /tmp/akmods-rpms
+dnf5 install -y skopeo jq
 skopeo copy --retry-times 3 \
     "docker://ghcr.io/ublue-os/akmods-nvidia-open:${AKMODS_FLAVOR}-$(rpm -E %fedora)-${KERNEL}" \
     dir:/tmp/akmods-rpms

--- a/build/README.md
+++ b/build/README.md
@@ -1,6 +1,6 @@
 # Build Scripts
 
-This directory contains build scripts that run during image creation. Scripts are executed in numerical order.
+This directory contains build scripts used during image creation. The default Containerfile explicitly runs the required scripts; extra scripts must be explicitly added to the Containerfile.
 
 ## How It Works
 
@@ -14,11 +14,22 @@ Scripts are named with a number prefix (e.g., `10-build.sh`, `20-onepassword.sh`
 
 - **`20-onepassword.sh.example`** - Example showing how to install software from third-party RPM repositories (Google Chrome, 1Password)
 - **`30-cosmic-desktop.sh.example`** - Example showing how to replace the GNOME desktop with COSMIC desktop
+- **`40-nvidia.sh.example`** - Example showing how to add NVIDIA drivers and CDI container support
 
 To use an example script:
-1. Remove the `.example` extension
-2. Make it executable: `chmod +x build/20-yourscript.sh`
-3. The build system will automatically run it in numerical order
+1. Rename it to remove the `.example` extension (for example, `mv build/20-onepassword.sh.example build/20-onepassword.sh`).
+2. Add the standard `RUN` block below after the `10-build.sh` block in `Containerfile`, replacing `NN-example.sh` with the renamed script.
+3. Run `just build`.
+
+```dockerfile
+RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    --mount=type=cache,dst=/var/cache/rpm-ostree \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    --mount=type=tmpfs,dst=/boot \
+    --mount=type=tmpfs,dst=/tmp \
+    /ctx/build/NN-example.sh
+```
 
 ## Creating Your Own Scripts
 
@@ -44,7 +55,7 @@ echo "Running custom setup..."
 
 ### Best Practices
 
-- **Use descriptive names**: `20-nvidia-drivers.sh` is better than `20-stuff.sh`
+- **Use descriptive names**: `40-nvidia.sh` is better than `40-stuff.sh`
 - **One purpose per script**: Easier to debug and maintain
 - **Clean up after yourself**: Remove temporary files and disable temporary repos
 - **Test incrementally**: Add one script at a time and test builds
@@ -52,23 +63,11 @@ echo "Running custom setup..."
 
 ### Disabling Scripts
 
-To temporarily disable a script without deleting it:
-- Rename it with `.disabled` extension: `20-script.sh.disabled`
-- Or remove execute permission: `chmod -x build/20-script.sh`
+To disable an activated script, remove its corresponding `RUN` block from `Containerfile` and rename it back to `.example` (or remove it).
 
 ## Execution Order
 
-The Containerfile runs scripts like this:
-
-```dockerfile
-RUN /ctx/build/10-build.sh
-```
-
-If you want to run multiple scripts, you can:
-
-1. **Modify Containerfile** to run each script explicitly
-2. **Create a runner script** that executes all numbered scripts
-3. **Use the default** and keep everything in `10-build.sh` (simplest)
+The template runs scripts explicitly, rather than automatically discovering files by prefix. Place extra script blocks after `10-build.sh` and before `clean-stage.sh`. Use numbered names to communicate the intended order.
 
 ## Notes
 


### PR DESCRIPTION
- Add an optional NVIDIA driver and CDI container-toolkit build-script example.
- Document the explicit Containerfile RUN block required to activate any example build script.
- Update existing example instructions and NVIDIA references to the shared activation pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional NVIDIA GPU provisioning via an example build script, including NVIDIA Container Toolkit setup and stricter validation for expected NVIDIA packages and common Wayland/kernel-argument requirements.
* **Documentation**
  * Updated guidance to require explicit activation: rename `.sh.example` files and add the corresponding `Containerfile` `RUN` block after `10-build.sh` (with a clear disable path by reversing those steps).
  * Expanded the example-script activation/validation instructions and added an NVIDIA-specific troubleshooting section for typical boot, driver, akmods, Vulkan/ICD conflicts, and GPU passthrough problems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->