### PR TITLE
fix(packages): install gum for default ujust recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here are the changes from [Base Image Name]. This image is based on [Bluefin/Baz
 
 ### Added Packages (Build-time)
 
-- **System packages**: tmux, micro, mosh - [brief explanation of why]
+- **System packages**: `tmux` and `gum` — tmux is the template's package-manager cache smoke test, and gum provides the interactive prompts used by the default ujust recipes.
 
 ### Added Applications (Runtime)
 

--- a/build/10-build.sh
+++ b/build/10-build.sh
@@ -50,9 +50,9 @@ echo "::endgroup::"
 
 echo "::group:: Install Packages"
 
-# Install a minimal package to verify the cache is working
-# This ensures the DNF cache is populated for future builds
-dnf5 install -y tmux
+# Install the default packages and verify the DNF cache is working.
+# gum is required by the default ujust recipes for interactive prompts.
+dnf5 install -y tmux gum
 
 # Example using COPR with isolated pattern:
 # copr_install_isolated "ublue-os/staging" package-name

--- a/custom/ujust/README.md
+++ b/custom/ujust/README.md
@@ -92,7 +92,7 @@ install-something:
 ```
 
 ### User Prompts
-Use `gum` for interactive prompts (included in Universal Blue images):
+Use `gum` for interactive prompts. The template installs it at build time because the default ujust recipes depend on it:
 ```just
 interactive-command:
     #!/usr/bin/bash


### PR DESCRIPTION
## Summary

- Install `gum` alongside the existing `tmux` package in `build/10-build.sh`.
- Document that the default ujust recipes require the build-time `gum` dependency.
- Update the template customization summary.

Fixes #50

## Validation

- `just --list` passed.
- `just check` passed.
- `bash -n build/10-build.sh` passed.
- `git diff --check` passed.
- `just lint` was attempted but could not run because `shellcheck` is not installed in the environment.