### PR TITLE
fix: stop installing Bluefin just recipes

### DIFF
--- a/build/10-build.sh
+++ b/build/10-build.sh
@@ -16,16 +16,6 @@ source /ctx/build/copr-helpers.sh
 # Enable nullglob for all glob operations to prevent failures on empty matches
 shopt -s nullglob
 
-echo "::group:: Copy Bluefin Config from Common"
-
-# Copy just files from @projectbluefin/common (includes 00-entry.just which imports 60-custom.just)
-mkdir -p /usr/share/ublue-os/just/
-shopt -s nullglob
-cp -r /ctx/oci/common/bluefin/usr/share/ublue-os/just/* /usr/share/ublue-os/just/
-shopt -u nullglob
-
-echo "::endgroup::"
-
 echo "::group:: Overlay Brew Integration Files"
 
 # Brew integration files from @ublue-os/brew OCI (tarball, systemd services, shell integration)
@@ -40,6 +30,7 @@ mkdir -p /usr/share/ublue-os/homebrew/
 cp /ctx/custom/brew/*.Brewfile /usr/share/ublue-os/homebrew/
 
 # Consolidate Just Files
+mkdir -p /usr/share/ublue-os/just/
 find /ctx/custom/ujust -iname '*.just' -exec printf "\n\n" \; -exec cat {} \; >>/usr/share/ublue-os/just/60-custom.just
 
 # Copy Flatpak preinstall files

--- a/custom/ujust/README.md
+++ b/custom/ujust/README.md
@@ -9,8 +9,9 @@ This directory contains Just recipe files that will be installed into your custo
 ## How It Works
 
 1. **During Build**: All `.just` files in this directory are consolidated and copied to `/usr/share/ublue-os/just/60-custom.just` in the image
-2. **After Installation**: Users run `ujust` to see available commands
-3. **User Experience**: Simple command interface for system tasks
+2. **Automatic Import**: The base `ublue-os-just` package imports `60-custom.just`; Bluefin recipes from `projectbluefin/common` remain available in the build context but are not installed by default
+3. **After Installation**: Users run `ujust` to see available commands
+4. **User Experience**: Simple command interface for system tasks
 
 ## File Structure
 


### PR DESCRIPTION
## Summary

- stop copying Bluefin-specific just recipes from `projectbluefin/common` into downstream images
- keep local recipes consolidated in `60-custom.just`, which the base `ublue-os-just` package already imports
- document that common recipes remain opt-in build-context resources

## Validation

- `shellcheck build/10-build.sh`
- `just --list`
- `just check`
- `git diff --check`

Closes #52
