### PR TITLE
feat(agents): adopt discoverable skill layout

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -10,9 +10,10 @@ file whose frontmatter tells compatible agents when to load it.
 
 | Skill | What it covers |
 |---|---|
-| [`finpilot-overview`](finpilot-overview/SKILL.md) | Repository architecture, file layout, and the task router table. **Start here.** |
-| [`finpilot-onboarding`](finpilot-onboarding/SKILL.md) | Bootstrap a new fork: rename, enable Actions, first green build, signing. |
-| [`finpilot-templates`](finpilot-templates/SKILL.md) | The 7 rename locations and template-repo maintenance rules. |
+| [`finpilot-router`](finpilot-router/SKILL.md) | The task routing table: which skill covers what, and the standard sequence. Load when unsure. |
+| [`finpilot-overview`](finpilot-overview/SKILL.md) | Repository architecture and file layout. Start here for orientation. |
+| [`finpilot-onboarding`](finpilot-onboarding/SKILL.md) | Bootstrap a new fork: rename, enable Actions, first green build, raptor section, branch protection. |
+| [`finpilot-templates`](finpilot-templates/SKILL.md) | The 7 rename locations, image identity ARGs, signing setup, AGENTS.md update rules. |
 | [`finpilot-packages`](finpilot-packages/SKILL.md) | Decision tree: where to add packages (dnf5, Brew, Flatpak). |
 | [`finpilot-custom`](finpilot-custom/SKILL.md) | Runtime layer: Brewfiles, Flatpaks, ujust, and validation. |
 | [`finpilot-build`](finpilot-build/SKILL.md) | Containerfile, Justfile, build scripts, image pinning, advanced topics. |
@@ -22,18 +23,8 @@ file whose frontmatter tells compatible agents when to load it.
 | [`finpilot-pr-checklist`](finpilot-pr-checklist/SKILL.md) | Pre-commit and per-change-type validation checklists. |
 | [`finpilot-examples`](finpilot-examples/SKILL.md) | Runnable example scripts and the `.example` → `.sh` activation pattern. |
 
-## Quick Router
-
-| I need to… | Read this skill |
-|---|---|
-| Bootstrap a new fork from this template | `finpilot-onboarding` |
-| Add/remove a package or app | `finpilot-packages` |
-| Change Brewfiles, Flatpaks, or ujust | `finpilot-custom` |
-| Change Containerfile, Justfile, or build scripts | `finpilot-build` |
-| Fix CI or Renovate | `finpilot-ci` / `finpilot-maintain` |
-| Open a PR | `finpilot-pr-checklist` |
-| Debug a build or deploy failure | `finpilot-troubleshooting` |
-| Follow a worked example | `finpilot-examples` |
+Looking for "I need to… → which skill?" — that table lives in
+[`finpilot-router`](finpilot-router/SKILL.md), its single canonical home.
 
 ## How to Extend Skills
 
@@ -43,7 +34,8 @@ When adding a new skill:
 2. **Add `SKILL.md`** with `name` and `description` frontmatter; `name` must match the directory
 3. **Describe when to use the skill** precisely so agents can select it automatically
 4. **Include the standard sections**: When to Use, When NOT to Use, Core Process, Common Rationalizations, Red Flags, Verification
-5. **Add the skill to this README** and the `finpilot-overview` task router
+5. **Add the skill to this README** and to the routing table in `finpilot-router/SKILL.md`
+6. **Keep `SKILL.md` focused** — split deep sub-topics into sibling `.md` files in the same directory and link them from `SKILL.md` (relative links, e.g. `[AGENT-BRIEF.md](AGENT-BRIEF.md)`)
 
 ## References
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -2,48 +2,51 @@
 
 ## About
 
-This directory contains task-oriented skill files for the finpilot bootc image template. Skills follow the Bluefin `docs/skills` pattern: each skill defines **when to use it**, **when not to**, the **core process**, **common rationalizations**, **red flags**, and a **verification checklist**.
+This directory contains discoverable Agent Skills for the finpilot bootc image
+template. Each skill lives in a lowercase directory with a required `SKILL.md`
+file whose frontmatter tells compatible agents when to load it.
 
 ## Skill Index
 
 | Skill | What it covers |
 |---|---|
-| `finpilot-overview.md` | Repository architecture, file layout, and the task router table. **Start here.** |
-| `finpilot-onboarding.md` | Bootstrap a new fork: rename, enable Actions, first green build, signing. |
-| `finpilot-templates.md` | The 7 rename locations and template-repo maintenance rules. |
-| `finpilot-packages.md` | Decision tree: where to add packages (dnf5, Brew, Flatpak). |
-| `finpilot-custom.md` | Runtime layer: Brewfiles, Flatpaks, ujust, and validation. |
-| `finpilot-build.md` | Containerfile, Justfile, build scripts, image pinning, advanced topics. |
-| `finpilot-ci.md` | GitHub Actions, Renovate, composite actions, workflow pins. |
-| `finpilot-maintain.md` | Ongoing work: Renovate PRs, README raptor updates, local test loops. |
-| `finpilot-troubleshooting.md` | Symptom → cause → fix tables for build, CI, and runtime issues. |
-| `finpilot-pr-checklist.md` | Pre-commit and per-change-type validation checklists. |
-| `finpilot-examples.md` | Runnable example scripts and the `.example` → `.sh` activation pattern. |
+| [`finpilot-overview`](finpilot-overview/SKILL.md) | Repository architecture, file layout, and the task router table. **Start here.** |
+| [`finpilot-onboarding`](finpilot-onboarding/SKILL.md) | Bootstrap a new fork: rename, enable Actions, first green build, signing. |
+| [`finpilot-templates`](finpilot-templates/SKILL.md) | The 7 rename locations and template-repo maintenance rules. |
+| [`finpilot-packages`](finpilot-packages/SKILL.md) | Decision tree: where to add packages (dnf5, Brew, Flatpak). |
+| [`finpilot-custom`](finpilot-custom/SKILL.md) | Runtime layer: Brewfiles, Flatpaks, ujust, and validation. |
+| [`finpilot-build`](finpilot-build/SKILL.md) | Containerfile, Justfile, build scripts, image pinning, advanced topics. |
+| [`finpilot-ci`](finpilot-ci/SKILL.md) | GitHub Actions, Renovate, composite actions, workflow pins. |
+| [`finpilot-maintain`](finpilot-maintain/SKILL.md) | Ongoing work: Renovate PRs, README raptor updates, local test loops. |
+| [`finpilot-troubleshooting`](finpilot-troubleshooting/SKILL.md) | Symptom → cause → fix tables for build, CI, and runtime issues. |
+| [`finpilot-pr-checklist`](finpilot-pr-checklist/SKILL.md) | Pre-commit and per-change-type validation checklists. |
+| [`finpilot-examples`](finpilot-examples/SKILL.md) | Runnable example scripts and the `.example` → `.sh` activation pattern. |
 
 ## Quick Router
 
 | I need to… | Read this skill |
 |---|---|
-| Bootstrap a new fork from this template | `finpilot-onboarding.md` |
-| Add/remove a package or app | `finpilot-packages.md` |
-| Change Brewfiles, Flatpaks, or ujust | `finpilot-custom.md` |
-| Change Containerfile, Justfile, or build scripts | `finpilot-build.md` |
-| Fix CI or Renovate | `finpilot-ci.md` / `finpilot-maintain.md` |
-| Open a PR | `finpilot-pr-checklist.md` |
-| Debug a build or deploy failure | `finpilot-troubleshooting.md` |
-| Follow a worked example | `finpilot-examples.md` |
+| Bootstrap a new fork from this template | `finpilot-onboarding` |
+| Add/remove a package or app | `finpilot-packages` |
+| Change Brewfiles, Flatpaks, or ujust | `finpilot-custom` |
+| Change Containerfile, Justfile, or build scripts | `finpilot-build` |
+| Fix CI or Renovate | `finpilot-ci` / `finpilot-maintain` |
+| Open a PR | `finpilot-pr-checklist` |
+| Debug a build or deploy failure | `finpilot-troubleshooting` |
+| Follow a worked example | `finpilot-examples` |
 
 ## How to Extend Skills
 
 When adding a new skill:
 
-1. **Copy an existing skill** as a template to maintain consistency
-2. **Use frontmatter** with `name`, `description`, and `metadata` keys
-3. **Include the standard sections**: When to Use, When NOT to Use, Core Process, Common Rationalizations, Red Flags, Verification
-4. **Add to this README** in the index and quick router tables
-5. **Link to the new skill** from `finpilot-overview.md` and wherever else relevant
+1. **Create a lowercase, hyphenated directory** under `.agents/skills/`
+2. **Add `SKILL.md`** with `name` and `description` frontmatter; `name` must match the directory
+3. **Describe when to use the skill** precisely so agents can select it automatically
+4. **Include the standard sections**: When to Use, When NOT to Use, Core Process, Common Rationalizations, Red Flags, Verification
+5. **Add the skill to this README** and the `finpilot-overview` task router
 
 ## References
 
-- [Bluefin skills](https://github.com/projectbluefin/bluefin/tree/main/docs/skills) — upstream pattern
+- [Adding agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills)
+- [Agent Skills specification](https://agentskills.io/specification)
 - [AGENTS.md](../../AGENTS.md) — high-level copilot instructions and mandatory gates

--- a/.agents/skills/finpilot-build/SKILL.md
+++ b/.agents/skills/finpilot-build/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 ## When NOT to Use
 
 - CI workflow changes (`.github/workflows/`) — use `finpilot-ci`
-- Runtime customizations (`custom/`) — use the README.md guides
+- Runtime customizations (`custom/`) — use `finpilot-custom`
 
 ## Core Process
 

--- a/.agents/skills/finpilot-build/SKILL.md
+++ b/.agents/skills/finpilot-build/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   Containerfile multi-stage build, image digest pinning in FROM lines,
   Justfile local build recipes, and build script conventions.
   Use when changing Containerfile, Justfile, or build/*.sh.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Build System
@@ -19,7 +17,7 @@ metadata:
 
 ## When NOT to Use
 
-- CI workflow changes (`.github/workflows/`) — see `finpilot-ci.md`
+- CI workflow changes (`.github/workflows/`) — use `finpilot-ci`
 - Runtime customizations (`custom/`) — use the README.md guides
 
 ## Core Process

--- a/.agents/skills/finpilot-ci/SKILL.md
+++ b/.agents/skills/finpilot-ci/SKILL.md
@@ -3,7 +3,7 @@ name: finpilot-ci
 description: >-
   GitHub Actions workflows, projectbluefin/actions composite actions,
   Renovate configuration, and PR validation for finpilot.
-  Use when changing .github/workflows/, renovate.json, or .hadolint.yaml.
+  Use when changing .github/workflows/, .github/renovate.json, or .hadolint.yaml.
 ---
 
 # finpilot CI
@@ -19,7 +19,7 @@ description: >-
 ## When NOT to Use
 
 - Containerfile / Justfile / build script changes — use `finpilot-build`
-- Runtime customisations — use README.md guides
+- Runtime customisations — use `finpilot-custom`
 
 ## Core Process
 
@@ -40,7 +40,7 @@ description: >-
 | `validate-brewfiles.yml` | PR paths: `custom/brew/**`        | Homebrew Brewfile syntax check                       |
 | `validate-flatpaks.yml`  | PR paths: `custom/flatpaks/**`    | Flathub app ID existence check                       |
 | `validate-justfiles.yml` | PR paths: `Justfile`              | `just --list` syntax check                           |
-| `validate-renovate.yml`  | PR paths: `renovate.json`         | `renovate-config-validator`                          |
+| `validate-renovate.yml`  | PR paths: `.github/renovate.json` | `renovate-config-validator`                          |
 
 ## Composite Action Pins
 
@@ -117,29 +117,20 @@ to users' machines.
 
 ## Renovate OCI Digest Tracking
 
-All OCI image digests are pinned inline in `Containerfile` `FROM` lines and tracked
-by Renovate's built-in `dockerfile` manager:
-
-```dockerfile
-FROM ghcr.io/projectbluefin/common:latest@sha256:<current> AS common
-FROM ghcr.io/ublue-os/brew:latest@sha256:<current> AS brew
-ARG FEDORA_MAJOR_VERSION="44"
-FROM quay.io/fedora-ostree-desktops/silverblue:44@sha256:<current>
-```
+All OCI image digests are pinned inline in `Containerfile` `FROM` lines and
+tracked by Renovate's built-in `dockerfile` manager — pinning pattern:
+`finpilot-build`.
 
 When Renovate updates a digest it opens a PR that changes only the relevant
 `Containerfile` line. The next CI build uses it directly.
 
 ## Renovate Workflow Requirements
 
-The self-hosted Renovate runner requires a `RENOVATE_TOKEN` secret:
-
-- **Classic PAT** with `repo` + `workflow` scopes
-- Set in repository secrets as `RENOVATE_TOKEN`
-- The `check-token-health` composite action validates this at the start of the workflow
-
-If `RENOVATE_TOKEN` is missing or expired, the workflow fails **before** running Renovate —
-not midway through — thanks to the preflight check.
+The self-hosted Renovate runner requires a `RENOVATE_TOKEN` (Classic PAT with
+`repo` + `workflow` scopes; creation: `finpilot-onboarding`). The
+`check-token-health` composite action validates it at the start of the workflow,
+so a missing or expired token fails the workflow **before** running Renovate —
+not midway through.
 
 ## hadolint Config (.hadolint.yaml)
 

--- a/.agents/skills/finpilot-ci/SKILL.md
+++ b/.agents/skills/finpilot-ci/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   GitHub Actions workflows, projectbluefin/actions composite actions,
   Renovate configuration, and PR validation for finpilot.
   Use when changing .github/workflows/, renovate.json, or .hadolint.yaml.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot CI
@@ -20,7 +18,7 @@ metadata:
 
 ## When NOT to Use
 
-- Containerfile / Justfile / build script changes — see `finpilot-build.md`
+- Containerfile / Justfile / build script changes — use `finpilot-build`
 - Runtime customisations — use README.md guides
 
 ## Core Process

--- a/.agents/skills/finpilot-custom/SKILL.md
+++ b/.agents/skills/finpilot-custom/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: finpilot-custom
 description: >-
-  Runtime layer documentation for Brewfiles, Flatpaks, and ujust commands.
-  Covers syntax, placement, validation workflows, and the critical rule:
-  NEVER use dnf5 in just files. Use when modifying custom/ or explaining
-  the runtime layer to contributors.
+  Runtime layer of finpilot: Brewfiles, Flatpaks, and ujust commands — syntax,
+  placement, and validation. Use when modifying custom/ or explaining the
+  runtime layer to contributors.
 ---
 
 # finpilot Runtime Layer
@@ -32,7 +31,7 @@ description: >-
 
 ## Brewfiles: `custom/brew/*.Brewfile`
 
-Brewfiles use Ruby syntax. They define Homebrew packages installed by users after deployment.
+Brewfiles use Ruby syntax. They define Homebrew packages installed by users after deployment. Homebrew itself is pre-staged at build time via the `@ublue-os/brew` OCI container and extracted on first boot by `brew-setup.service`; Brewfiles define what users install after that extraction.
 
 ### File Locations
 
@@ -107,14 +106,10 @@ Branch=stable
 
 ### Key Rules
 
-- **Post-first-boot only**: Flatpaks are NOT baked into the ISO or container. They install on first boot with internet access.
+- **Post-first-boot only**: Flatpaks are NOT baked into the ISO or container. They install on first boot with internet access — do not rely on them in offline scenarios or ISO-based installs without network.
 - **Always specify `Branch=stable`** (or another valid branch)
 - **Find app IDs at https://flathub.org/**
 - **Validation**: `validate-flatpaks.yml` checks that app IDs exist on Flathub
-
-### Important Note
-
-Flatpaks require an internet connection on first boot. Do not rely on them being available in offline scenarios or during ISO-based installs without network.
 
 ## ujust: `custom/ujust/*.just`
 

--- a/.agents/skills/finpilot-custom/SKILL.md
+++ b/.agents/skills/finpilot-custom/SKILL.md
@@ -5,8 +5,6 @@ description: >-
   Covers syntax, placement, validation workflows, and the critical rule:
   NEVER use dnf5 in just files. Use when modifying custom/ or explaining
   the runtime layer to contributors.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Runtime Layer
@@ -21,9 +19,9 @@ metadata:
 
 ## When NOT to Use
 
-- Build script changes — see `finpilot-build.md`
-- CI workflow changes — see `finpilot-ci.md`
-- Adding system packages at build-time — see `finpilot-packages.md`
+- Build script changes — use `finpilot-build`
+- CI workflow changes — use `finpilot-ci`
+- Adding system packages at build-time — use `finpilot-packages`
 
 ## Core Process
 

--- a/.agents/skills/finpilot-examples/SKILL.md
+++ b/.agents/skills/finpilot-examples/SKILL.md
@@ -76,7 +76,7 @@ All NVIDIA logic is self-contained in the script. It provisions NVIDIA support d
 **What it does:**
 
 - Adds the 1Password repository
-- Installs `1password` and `1password-cli`
+- Installs `1password`
 - Removes the repo file after install (isolated install pattern)
 
 **How to activate:**
@@ -124,7 +124,7 @@ When adding a new pattern that others might reuse, create an `.example` file:
 1. **Name it** with the correct prefix: `20-` for third-party repos, `30-` for desktop swaps
 2. **Include comments** explaining what it does and how to customize
 3. **Follow conventions**: `set -euo pipefail`, `dnf5`, `copr_install_isolated` for COPRs
-4. **Add to this skill** (or `AGENTS.md`) so agents know it exists
+4. **Add the new example to this skill** so agents discover it
 
 ### Template for New Examples
 

--- a/.agents/skills/finpilot-examples/SKILL.md
+++ b/.agents/skills/finpilot-examples/SKILL.md
@@ -5,8 +5,6 @@ description: >-
   existing .example files and how to activate them.
   Use when adding new build scripts or explaining the activation pattern to
   contributors.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Example Scripts
@@ -156,7 +154,7 @@ set -euo pipefail
 
 ## Link to Package Decision Tree
 
-For deciding whether to use an example script or add directly to `build/10-build.sh`, see `finpilot-packages.md`.
+For deciding whether to use an example script or add directly to `build/10-build.sh`, use `finpilot-packages`.
 
 **Quick guide:**
 

--- a/.agents/skills/finpilot-maintain/SKILL.md
+++ b/.agents/skills/finpilot-maintain/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: finpilot-maintain
 description: >-
-  Ongoing maintenance skill for finpilot forks. Covers Renovate digest PRs,
-  README raptor section updates, signing enablement, local test loops,
-  and maintenance schedules. Use when maintaining an active fork after
-  the initial onboarding.
+  Maintenance of an active finpilot fork: Renovate digest PRs, README raptor
+  section updates, signing enablement, local test loops, and maintenance
+  schedules. Use when maintaining a fork after onboarding.
 ---
 
 # finpilot Maintenance
@@ -54,7 +53,7 @@ For PRs with non-digest changes (e.g., major version bumps), review manually bef
 
 ## Update README Raptor Section
 
-The "What Makes this Raptor Different?" section in `README.md` must be updated on **every package or configuration change**.
+The "What Makes this Raptor Different?" section in `README.md` must be updated on **every package or configuration change**. The full section template is in `finpilot-onboarding`.
 
 ### When to Update
 
@@ -73,27 +72,15 @@ The "What Makes this Raptor Different?" section in `README.md` must be updated o
 _Last updated: [date]_
 ```
 
-Always update the date. Keep descriptions brief and user-focused.
+Always update the date. Keep descriptions brief and user-focused, written for
+typical Linux users, not developers.
 
 ## Enable Signing When Ready for Production
 
-Signing is **disabled by default** to allow first builds to succeed. Enable when your fork is stable and publishing production images.
-
-### Steps
-
-1. Edit `.github/workflows/build-image.yml`
-2. Find the `# OPTIONAL: Sign and attest` section
-3. Uncomment the `Sign and publish` step
-4. Commit and push (via PR to `main`)
-
-### Verification After Enablement
-
-```bash
-cosign verify \
-  --certificate-identity-regexp="https://github.com/YOUR_ORG/YOUR_REPO/.github/workflows/" \
-  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  ghcr.io/YOUR_ORG/YOUR_REPO:stable
-```
+Signing is **disabled by default** to allow first builds to succeed. Enable when
+your fork is stable: uncomment the `Sign and publish` step in
+`.github/workflows/build-image.yml` — full setup and verification:
+`finpilot-templates`.
 
 ## Local Test Loop
 
@@ -140,30 +127,21 @@ just run-vm-iso
 
 ### Always Open a PR to `main`
 
-- Direct pushes to `main` are **not recommended**
-- PRs trigger `pr-validation.yml` and other `validate-*.yml` checks
-- Branch protection should require PRs with the `validate` status check
+Direct pushes to `main` bypass validation and create untraceable changes. PRs
+trigger `pr-validation.yml` and the `validate-*.yml` checks; branch protection
+should require PRs with the `validate` status check (setup: `finpilot-onboarding`).
 
 ### PR Best Practices
 
-- Use **Conventional Commits** (e.g., `feat:`, `fix:`, `chore:`)
-- Keep changes focused — one concern per PR
-- Reference the relevant issue or context in the PR description
-- Ensure all `validate` checks pass before requesting review
+Use Conventional Commits and the change-type checklists — see
+`finpilot-pr-checklist`.
 
 ## Keeping OCI Digests Current via Renovate
 
-Renovate handles digest updates automatically. Ensure:
-
-1. **`RENOVATE_TOKEN` is valid** (Classic PAT, `repo` + `workflow` scopes)
-2. **Renovate workflow is enabled** (`.github/workflows/renovate.yml`)
-3. **Auto-merge is enabled** for digest-only PRs
-
-If Renovate is not creating PRs, check:
-
-- Token expiry
-- Workflow enabled/disabled status
-- `renovate.json` syntax (`renovate-config-validator`)
+Renovate handles digest updates automatically. It needs a valid `RENOVATE_TOKEN`
+(setup: `finpilot-onboarding`), the Renovate workflow enabled, and auto-merge for
+digest-only PRs. If Renovate stops creating PRs, run the Renovate section of
+`finpilot-troubleshooting`.
 
 ## Maintenance Schedule Recommendations
 

--- a/.agents/skills/finpilot-maintain/SKILL.md
+++ b/.agents/skills/finpilot-maintain/SKILL.md
@@ -5,8 +5,6 @@ description: >-
   README raptor section updates, signing enablement, local test loops,
   and maintenance schedules. Use when maintaining an active fork after
   the initial onboarding.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Maintenance
@@ -21,9 +19,9 @@ metadata:
 
 ## When NOT to Use
 
-- First-time fork setup — see `finpilot-onboarding.md`
-- Adding new packages for the first time — see `finpilot-packages.md`
-- Debugging a specific build failure — see `finpilot-troubleshooting.md`
+- First-time fork setup — use `finpilot-onboarding`
+- Adding new packages for the first time — use `finpilot-packages`
+- Debugging a specific build failure — use `finpilot-troubleshooting`
 
 ## Core Process
 

--- a/.agents/skills/finpilot-onboarding/SKILL.md
+++ b/.agents/skills/finpilot-onboarding/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: finpilot-onboarding
 description: >-
-  Fork bootstrap agent playbook. Covers the 7 rename locations, first green build,
-  README "What Makes this Raptor Different" section, optional signing setup, and
-  branch protection configuration. Use when creating a new fork from this template.
+  Fork bootstrap playbook: the 7 rename locations, first green build,
+  README "What Makes this Raptor Different" section, and branch protection.
+  Use when creating a new fork from this template.
 ---
 
 # finpilot Onboarding
@@ -24,29 +24,19 @@ description: >-
 ## Core Process
 
 1. **Fork the template**: Use "Use this template" on GitHub to create a new repository
-2. **Rename all 7 locations** (see table below)
+2. **Rename all 7 locations** (table: `finpilot-templates`)
 3. **Enable GitHub Actions** in the new repository
 4. **Add `RENOVATE_TOKEN` secret** (Classic PAT with `repo` + `workflow` scopes)
 5. **Configure branch protection and auto-merge**
 6. **Trigger first build**
-7. **Add the "What Makes this Raptor Different" section to README**
-8. **Enable signing** (optional, recommended for production)
+7. **Add the "What Makes this Raptor Different" section to README** (template below)
+8. **Enable signing** (optional, recommended for production; setup: `finpilot-templates`)
 
-## The Seven Rename Locations
+Keep day-one changes minimal: validate the first green build before adding
+packages, Flatpaks, or Brewfiles — each phase validates the previous
+(`finpilot-packages` and `finpilot-custom` cover those phases).
 
-When forking, change `finpilot` → your image name in exactly these files:
-
-| #   | File                          | What to change                                                      |
-| --- | ----------------------------- | ------------------------------------------------------------------- |
-| 1   | `Containerfile`               | `ARG IMAGE_NAME="finpilot"` and `ARG IMAGE_VENDOR="projectbluefin"` |
-| 2   | `Justfile`                    | `export IMAGE_NAME := env("IMAGE_NAME", "finpilot")`                |
-| 3   | `README.md`                   | Title `# finpilot`                                                  |
-| 4   | `artifacthub-repo.yml`        | `repositoryID: finpilot`                                            |
-| 5   | `custom/ujust/README.md`      | `localhost/finpilot:stable` in the bootc switch example             |
-| 6   | `.github/workflows/clean.yml` | `packages: finpilot`                                                |
-| 7   | `iso/iso.toml`                | `ghcr.io/USERNAME/REPO:stable` in the bootc switch URL              |
-
-Missing any of these causes the image to be published or cleaned up under the wrong name.
+Each step's completion criterion is the matching item in the Verification checklist below.
 
 ## Enable GitHub Actions
 
@@ -126,46 +116,14 @@ Here are the changes from [Base Image Name]. This image is based on [Bluefin/Baz
 _Last updated: [date]_
 ```
 
-**Maintenance requirement**:
-
-- **ALWAYS update this section when you modify packages or configuration**
-- Keep descriptions brief and user-focused (explain "why", not just "what")
-- Write for typical Linux users, not developers
-- Update the "Last updated" date with each change
+**Maintenance requirement**: update this section on every package or
+configuration change — see the update rules in `finpilot-maintain`.
 
 ## Optional Signing Setup
 
-Signing is **disabled by default** so first builds succeed immediately. Enable later for production.
-
-This template uses **keyless OIDC signing** via Cosign + Fulcio. No `cosign.key` or static keys are needed.
-
-**To enable:**
-
-1. Edit `.github/workflows/build-image.yml`
-2. Find the `# OPTIONAL: Sign and attest` section
-3. Uncomment the `Sign and publish` step
-
-**Verification:**
-
-```bash
-cosign verify \
-  --certificate-identity-regexp="https://github.com/YOUR_ORG/YOUR_REPO/.github/workflows/" \
-  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  ghcr.io/YOUR_ORG/YOUR_REPO:stable
-```
-
-**Never commit `cosign.key` to the repository.** It is listed in `.gitignore` as a safety net.
-
-## Agent Playground Setup
-
-When setting up the fork, do not over-customize on day one. Use an **iterative approach**:
-
-1. **Phase 1**: Rename, enable Actions, add token, trigger first build
-2. **Phase 2**: Add one or two packages, run `just build`, verify locally
-3. **Phase 3**: Add Flatpak/Brew customizations, test in VM (`just run-vm-qcow2`)
-4. **Phase 4**: Enable signing, configure branch protection fully, production-ready
-
-Resist the urge to change everything at once. Each phase validates the previous.
+Signing is **disabled by default** so first builds succeed immediately. Enable
+later for production — full keyless OIDC setup and verification:
+`finpilot-templates`.
 
 ## Common Rationalizations
 

--- a/.agents/skills/finpilot-onboarding/SKILL.md
+++ b/.agents/skills/finpilot-onboarding/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   Fork bootstrap agent playbook. Covers the 7 rename locations, first green build,
   README "What Makes this Raptor Different" section, optional signing setup, and
   branch protection configuration. Use when creating a new fork from this template.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Onboarding
@@ -20,8 +18,8 @@ metadata:
 ## When NOT to Use
 
 - The repository is already initialized and has had a successful build
-- You are adding packages or changing build logic — see `finpilot-packages.md` or `finpilot-build.md`
-- You are updating CI workflows — see `finpilot-ci.md`
+- You are adding packages or changing build logic — use `finpilot-packages` or `finpilot-build`
+- You are updating CI workflows — use `finpilot-ci`
 
 ## Core Process
 

--- a/.agents/skills/finpilot-overview/SKILL.md
+++ b/.agents/skills/finpilot-overview/SKILL.md
@@ -3,7 +3,7 @@ name: finpilot-overview
 description: >-
   Architecture, repo layout, and factory role for the finpilot template.
   Use when orienting to the repository, understanding how it relates to
-  projectbluefin/actions, or deciding which skill to read next.
+  projectbluefin/actions, or before picking a skill with finpilot-router.
 ---
 
 # finpilot Overview
@@ -12,7 +12,7 @@ description: >-
 
 - Starting a new session in this repo
 - Explaining how finpilot relates to bluefin/aurora/dakota
-- Deciding which Agent Skill covers your change area
+- Orienting before using `finpilot-router` to pick a skill
 - Onboarding a new contributor or agent
 
 ## When NOT to Use
@@ -22,7 +22,7 @@ description: >-
 
 ## Core Process
 
-1. **Read AGENTS.md `## Start here`** for repository-wide rules
+1. **Read AGENTS.md `## Start here`** for repository-wide rules and the skill sequence
 2. **Identify your change area** (Containerfile/Justfile → build, workflows → ci, template init → templates)
 3. **Load the relevant skill** before touching anything
 4. **Verify against current patterns** in `projectbluefin/actions` before deviating
@@ -80,20 +80,10 @@ pipeline repo itself, but it adopts the same composite workflow actions as bluef
 - Renovate config extends `config:best-practices` and tracks OCI digests
 - Image metadata (`image-info.json`) follows the ublue-os convention
 
-## Task Router ("I need to…")
+## Task Router
 
-| I need to…                                       | Load this skill                           |
-| ------------------------------------------------ | ----------------------------------------- |
-| Bootstrap a new fork from this template          | `finpilot-onboarding`                  |
-| Add/remove a package or app                      | `finpilot-packages`                    |
-| Change Brewfiles, Flatpaks, or ujust             | `finpilot-custom`                      |
-| Change Containerfile, Justfile, or build scripts | `finpilot-build`                       |
-| Fix CI or Renovate                               | `finpilot-ci` / `finpilot-maintain`    |
-| Open a PR                                        | `finpilot-pr-checklist`                |
-| Debug a build or deploy failure                  | `finpilot-troubleshooting`             |
-| Follow a worked example                          | `finpilot-examples`                    |
-| Orient to repo architecture                      | `finpilot-overview` (this skill)       |
-| Initialize or rename this template               | `finpilot-templates`                   |
+The canonical task → skill routing table lives in the `finpilot-router` skill —
+load it when you don't know which skill covers a task.
 
 ## Scope Rules
 

--- a/.agents/skills/finpilot-overview/SKILL.md
+++ b/.agents/skills/finpilot-overview/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   Architecture, repo layout, and factory role for the finpilot template.
   Use when orienting to the repository, understanding how it relates to
   projectbluefin/actions, or deciding which skill to read next.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Overview
@@ -14,19 +12,19 @@ metadata:
 
 - Starting a new session in this repo
 - Explaining how finpilot relates to bluefin/aurora/dakota
-- Deciding which `.agents/skills/` file covers your change area
+- Deciding which Agent Skill covers your change area
 - Onboarding a new contributor or agent
 
 ## When NOT to Use
 
-- You already know the area — go straight to the relevant skill file
-- You need specific build or CI mechanics — see `finpilot-build.md` or `finpilot-ci.md`
+- You already know the area — use the relevant skill directly
+- You need specific build or CI mechanics — use `finpilot-build` or `finpilot-ci`
 
 ## Core Process
 
-1. **Read AGENTS.md `## Start here`** to find the routing table
+1. **Read AGENTS.md `## Start here`** for repository-wide rules
 2. **Identify your change area** (Containerfile/Justfile → build, workflows → ci, template init → templates)
-3. **Read the relevant skill file** before touching anything
+3. **Load the relevant skill** before touching anything
 4. **Verify against current patterns** in `projectbluefin/actions` before deviating
 
 ## Architecture
@@ -70,7 +68,7 @@ finpilot is a **bootc image template** following the Bluefin multi-stage build a
 │   ├── actions/
 │   │   └── check-token-health/  # PAT validation composite action
 │   └── renovate.json            # Renovate config (OCI digests, GH Actions)
-└── .agents/skills/        # This directory
+└── .agents/skills/        # Discoverable <skill-name>/SKILL.md directories
 ```
 
 ## Factory Role
@@ -86,22 +84,22 @@ pipeline repo itself, but it adopts the same composite workflow actions as bluef
 
 | I need to…                                       | Load this skill                           |
 | ------------------------------------------------ | ----------------------------------------- |
-| Bootstrap a new fork from this template          | `finpilot-onboarding.md`                  |
-| Add/remove a package or app                      | `finpilot-packages.md`                    |
-| Change Brewfiles, Flatpaks, or ujust             | `finpilot-custom.md`                      |
-| Change Containerfile, Justfile, or build scripts | `finpilot-build.md`                       |
-| Fix CI or Renovate                               | `finpilot-ci.md` / `finpilot-maintain.md` |
-| Open a PR                                        | `finpilot-pr-checklist.md`                |
-| Debug a build or deploy failure                  | `finpilot-troubleshooting.md`             |
-| Follow a worked example                          | `finpilot-examples.md`                    |
-| Orient to repo architecture                      | `finpilot-overview.md` (this file)        |
-| Initialize or rename this template               | `finpilot-templates.md`                   |
+| Bootstrap a new fork from this template          | `finpilot-onboarding`                  |
+| Add/remove a package or app                      | `finpilot-packages`                    |
+| Change Brewfiles, Flatpaks, or ujust             | `finpilot-custom`                      |
+| Change Containerfile, Justfile, or build scripts | `finpilot-build`                       |
+| Fix CI or Renovate                               | `finpilot-ci` / `finpilot-maintain`    |
+| Open a PR                                        | `finpilot-pr-checklist`                |
+| Debug a build or deploy failure                  | `finpilot-troubleshooting`             |
+| Follow a worked example                          | `finpilot-examples`                    |
+| Orient to repo architecture                      | `finpilot-overview` (this skill)       |
+| Initialize or rename this template               | `finpilot-templates`                   |
 
 ## Scope Rules
 
 To keep changes minimal and safe:
 
-- **Doc tasks** (README, skills markdown) → No CI impact, free to edit
+- **Doc tasks** (README, Agent Skills) → No CI impact, free to edit
 - **CI tasks** (`.github/workflows/`, `renovate.json`) → Trigger `pr-validation.yml`, must pass `actionlint` and `renovate-config-validator`
 - **Build tasks** (`Containerfile`, `build/`, `Justfile`) → Trigger full build, must pass `hadolint` + `shellcheck`
 - **Runtime tasks** (`custom/`) → Trigger respective `validate-*.yml`
@@ -126,17 +124,17 @@ To keep changes minimal and safe:
 
 | Rationalization                                      | Reality                                                             |
 | ---------------------------------------------------- | ------------------------------------------------------------------- |
-| "AGENTS.md has everything — no need to read skills." | AGENTS.md is for Copilot UX. Skills are the agent operating manual. |
+| "AGENTS.md has everything — no need to use skills." | AGENTS.md holds global rules. Skills provide task-specific instructions. |
 | "It's just a template repo, not factory infra."      | It ships workflow patterns to every fork. Mistakes multiply.        |
 
 ## Red Flags
 
-- Making Containerfile changes without reading `finpilot-build.md`
+- Making Containerfile changes without using `finpilot-build`
 - Adding a workflow without verifying the `projectbluefin/actions` composite action exists
 - Updating pinned `@sha256:...` digests in `Containerfile` manually instead of letting Renovate do it
 
 ## Verification
 
-- [ ] Do I know which skill file covers my change area?
-- [ ] Have I read that skill file?
+- [ ] Do I know which skill covers my change area?
+- [ ] Have I loaded that skill?
 - [ ] Does the change match current `projectbluefin/actions` patterns?

--- a/.agents/skills/finpilot-packages/SKILL.md
+++ b/.agents/skills/finpilot-packages/SKILL.md
@@ -105,77 +105,26 @@ See `build/20-onepassword.sh.example` for a complete working example.
 
 ## Runtime Brew: `custom/brew/*.Brewfile`
 
-Homebrew packages are installed by users after deployment. Best for CLI tools and development environments.
-
-**Note:** Homebrew itself is pre-staged at build time via `@ublue-os/brew` OCI container and extracted on first boot by `brew-setup.service`. Brewfiles define what users install *after* that extraction.
-
-**Files:**
-
-- `custom/brew/default.Brewfile` — General purpose CLI tools
-- `custom/brew/development.Brewfile` — Development tools and environments
-- `custom/brew/fonts.Brewfile` — Font packages
-- Create custom `*.Brewfile` as needed
-
-**Example:**
-
-```ruby
-# In custom/brew/default.Brewfile
-brew "bat"        # cat with syntax highlighting
-brew "eza"        # Modern replacement for ls
-brew "ripgrep"    # Faster grep
-brew "fd"         # Simple alternative to find
-```
-
-**Users install via:** `ujust install-default-apps` (shortcut in `custom/ujust/`)
+Homebrew is for CLI tools and development environments, installed by users
+after first boot. File locations, syntax, and validation:
+`finpilot-custom`.
 
 ## Runtime Flatpak: `custom/flatpaks/*.preinstall`
 
-Flatpak applications are GUI apps installed after first boot. Use INI format.
-
-**Files:**
-
-- `custom/flatpaks/default.preinstall` — Default GUI applications
-- Create custom `*.preinstall` files as needed
-
-**Example:**
-
-```ini
-# In custom/flatpaks/default.preinstall
-[Flatpak Preinstall org.mozilla.firefox]
-Branch=stable
-
-[Flatpak Preinstall com.visualstudio.code]
-Branch=stable
-```
-
-**Important:**
-
-- Installed post-first-boot (not in ISO/container)
-- Requires internet connection
-- Find app IDs at https://flathub.org/
-- Always specify `Branch=stable` (or another branch)
+Flatpaks are for GUI apps, installed post-first-boot (not in the ISO or
+container). INI syntax, `Branch=stable`, Flathub ID lookup, and validation:
+`finpilot-custom`.
 
 ## Scope Rules
 
 ### Doc Tasks (No CI Impact)
 
-Changes that DO NOT trigger a CI build or validation:
-
-- Editing `README.md` (except if it changes build instructions)
-- Adding comments in build scripts
-- Updating `.gitignore`
-- Updating documentation in `custom/ujust/README.md`
+README edits, comments, `.gitignore`, and `custom/ujust/README.md` trigger no CI.
 
 ### CI Tasks (Trigger Validation/Build)
 
-Changes that DO trigger CI workflows:
-
-- Editing `build/*.sh` → triggers `pr-validation.yml` (shellcheck)
-- Editing `Containerfile` → triggers `pr-validation.yml` (hadolint) + build
-- Editing `custom/brew/*.Brewfile` → triggers `validate-brewfiles.yml`
-- Editing `custom/flatpaks/*.preinstall` → triggers `validate-flatpaks.yml`
-- Editing `Justfile` or `custom/ujust/*.just` → triggers `validate-justfiles.yml`
-- Editing `.github/workflows/*.yml` → triggers `actionlint` and build validation
+Which `validate-*.yml` workflow fires for your file type — see the Workflow Map
+in `finpilot-ci`.
 
 ## Common Rationalizations
 
@@ -201,6 +150,6 @@ Changes that DO trigger CI workflows:
 - [ ] For build-time: does it use `dnf5 install -y`?
 - [ ] For COPR: is `copr_install_isolated` used?
 - [ ] For third-party repo: is the repo file removed at end of script?
-- [ ] For BrewFraction: is the app ID verified on Flathub?
+- [ ] For Flatpak: is the app ID verified on Flathub?
 - [ ] For Brewfile: does `brew bundle check --file` pass locally?
-- [ ] Does the PR include the corresponding `validate-*.yml` trigger if applicable?
+- [ ] Does the changed path trigger the correct `validate-*.yml` workflow?

--- a/.agents/skills/finpilot-packages/SKILL.md
+++ b/.agents/skills/finpilot-packages/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   Decision tree for where to add packages in finpilot. Maps requests to the
   correct file and install method: build-time dnf5, runtime Brewfile, or
   runtime Flatpak. Use when deciding how to add a new package or tool.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Package Decision Tree
@@ -20,7 +18,7 @@ metadata:
 ## When NOT to Use
 
 - You already know the target file and install method — go edit it directly
-- You are debugging why a package fails to install — see `finpilot-troubleshooting.md`
+- You are debugging why a package fails to install — use `finpilot-troubleshooting`
 
 ## Core Process
 

--- a/.agents/skills/finpilot-pr-checklist/SKILL.md
+++ b/.agents/skills/finpilot-pr-checklist/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   PR gates and pre-commit checklist by change type. Covers validation commands
   for Containerfile, build scripts, Brewfiles, Flatpaks, ujust, workflows, and
   README changes. Use before opening or reviewing a PR.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot PR Checklist
@@ -20,7 +18,7 @@ metadata:
 ## When NOT to Use
 
 - The PR only contains documentation changes without affecting build/CI — still run markdown lint, but full checklist is overkill
-- You are troubleshooting an already-open PR — see `finpilot-troubleshooting.md`
+- You are troubleshooting an already-open PR — use `finpilot-troubleshooting`
 
 ## Core Process
 

--- a/.agents/skills/finpilot-router/SKILL.md
+++ b/.agents/skills/finpilot-router/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: finpilot-router
+description: >-
+  Task router for the finpilot repo: which skill covers what, and the
+  overview → domain → PR-checklist sequence. Use when unsure which skill
+  fits, or to add a skill to the routing table.
+---
+
+# finpilot Router
+
+## When to Use
+
+- You don't know which skill covers your task
+- You want the standard sequence before starting a multi-phase task
+- You are adding, renaming, or removing a skill
+- You are onboarding a new agent or contributor
+
+## When NOT to Use
+
+- You already know the area — load the matching skill directly, not this one
+- You need mechanics (build, CI, runtime) — those live in the domain skills
+
+## Core Process
+
+1. **Run the standard sequence** for an unfamiliar multi-phase task: start with
+   `finpilot-overview`, continue with the domain skill, finish with
+   `finpilot-pr-checklist`.
+2. **Find your task in the table** below and load the matching skill.
+
+| I need to…                                     | Load                                      |
+| ---------------------------------------------- | ----------------------------------------- |
+| Bootstrap a new fork                           | `finpilot-onboarding`                  |
+| Add/remove a package                           | `finpilot-packages`                    |
+| Change Brewfiles, Flatpaks, or ujust           | `finpilot-custom`                      |
+| Change Containerfile, Justfile, or build/\*.sh | `finpilot-build`                       |
+| Fix CI or Renovate                             | `finpilot-ci` / `finpilot-maintain`    |
+| Open a PR                                      | `finpilot-pr-checklist`                |
+| Debug a build or deploy failure                | `finpilot-troubleshooting`             |
+| Follow a worked example                        | `finpilot-examples`                    |
+| Initialize/ rename this template               | `finpilot-templates`                   |
+| Orient to repo architecture                    | `finpilot-overview`                    |
+| Pick a skill for a new task                    | `finpilot-router` (this skill)         |
+
+## Common Rationalizations
+
+| Rationalization                                          | Reality                                              |
+| -------------------------------------------------------- | ---------------------------------------------------- |
+| "The router table is in AGENTS.md — update it there."    | AGENTS.md holds rules. This skill owns the routing table, so it stays in sync with the skill set. |
+| "Every skill should list where it fits."                 | One table means one place to update; skills point here instead. |
+
+## Red Flags
+
+- A second routing table appears in AGENTS.md, `.agents/skills/README.md`, or a skill — route edits to this file
+- A new skill exists but is missing from this table
+
+## Verification
+
+- [ ] The table lists every skill in `.agents/skills/`
+- [ ] AGENTS.md and `.agents/skills/README.md` point here instead of carrying their own tables
+- [ ] `name` frontmatter matches the directory name

--- a/.agents/skills/finpilot-templates/SKILL.md
+++ b/.agents/skills/finpilot-templates/SKILL.md
@@ -1,35 +1,34 @@
 ---
 name: finpilot-templates
 description: >-
-  Template initialization, fork setup, renaming conventions, and the
-  seven files that must be updated when creating a new image from finpilot.
-  Use when initializing a fork, updating AGENTS.md, or documenting setup.
+  Template identity rules: the seven rename locations, image identity ARGs,
+  keyless signing setup, and AGENTS.md update rules. Use when renaming a fork,
+  enabling signing, or updating AGENTS.md and setup docs.
 ---
 
 # finpilot Templates & Fork Setup
 
 ## When to Use
 
-- Initializing a new custom OS image from this template
+- Renaming `finpilot` in a fork (the 7 locations)
+- Enabling or explaining keyless signing
 - Updating AGENTS.md or copilot instructions
 - Updating README.md setup sections or SETUP_CHECKLIST.md
 - Documenting new mandatory setup steps for forks
 
 ## When NOT to Use
 
+- First-time fork bootstrap procedure — use `finpilot-onboarding`
 - Build system changes — use `finpilot-build`
 - CI workflow changes — use `finpilot-ci`
 
-## Core Process: Creating a New Fork
+## Core Process
 
-1. **Click "Use this template"** on GitHub → create new repository
-2. **Rename `finpilot` in exactly 7 files** (see table below)
-3. **Enable GitHub Actions** in the Actions tab
-4. **Add `RENOVATE_TOKEN` secret** (Classic PAT, `repo` + `workflow` scopes)
-5. **Enable auto-merge** (Settings → General → Pull Requests → Allow auto-merge)
-6. **Configure branch protection for `main`** with `validate` as required check
-7. **Trigger first build** — push any commit or run the workflow manually
-8. **Enable signing** (optional) — uncomment `sign-and-publish` step in `build-image.yml`
+1. **Rename in the 7 locations** (table below)
+2. **Check the image identity ARGs** match the new name (below)
+3. **Enable keyless signing** when the fork is production-ready (below)
+4. **Update AGENTS.md** per the rules below
+5. **Verify** against the checklist at the end of this skill
 
 ## The Seven Rename Locations
 
@@ -41,7 +40,7 @@ When forking, change `finpilot` → your image name in exactly these locations:
 | 2   | `Justfile`                    | `export IMAGE_NAME := env("IMAGE_NAME", "finpilot")`                |
 | 3   | `README.md`                   | Title `# finpilot`                                                  |
 | 4   | `artifacthub-repo.yml`        | `repositoryID: finpilot`                                            |
-| 5   | `custom/ujust/README.md`      | `localhost/finpilot:stable` in the bootc switch example             |
+| 5   | `custom/ujust/README.md`      | `localhost/your-repo-name:stable` in the bootc switch example    |
 | 6   | `.github/workflows/clean.yml` | `packages: finpilot`                                                |
 | 7   | `iso/iso.toml`                | `ghcr.io/USERNAME/REPO:stable` in the bootc switch URL              |
 
@@ -85,13 +84,14 @@ cosign verify \
 
 **Never** add a `cosign.pub` file with a placeholder — it is misleading and was removed.
 Static-key signing (`SIGNING_SECRET`) is not supported by this template.
+**Never commit `cosign.key`** — it is `.gitignore`-d as a safety net.
 
 ## AGENTS.md Update Rules
 
 `AGENTS.md` is the Copilot instructions file. When updating it:
 
 - **Line-number references are fragile** — use semantic references (`ARG IMAGE_NAME`, `FROM`) not line numbers
-- **Keep the `## Start here` section pointing to the skills router table** — this is the factory pattern
+- **Keep the `## Start here` section pointing at the skills and the router** — this is the factory pattern
 - **Update `Last Updated` date** on every substantive change
 - **Do not add resolved items** (PR numbers, "✅ done" entries) — those belong in git history
 
@@ -114,9 +114,7 @@ Static-key signing (`SIGNING_SECRET`) is not supported by this template.
 ## Verification
 
 - [ ] All 7 rename locations updated?
-- [ ] GitHub Actions enabled in the fork?
-- [ ] `RENOVATE_TOKEN` secret added?
-- [ ] Auto-merge enabled in repository settings?
-- [ ] Branch protection for `main` configured with `validate` as required check?
-- [ ] First build triggered and succeeded?
+- [ ] `IMAGE_NAME` / `IMAGE_VENDOR` ARGs match the fork?
+- [ ] Signing enabled only via keyless OIDC (no `cosign.key`/`cosign.pub`)?
+- [ ] `AGENTS.md` uses semantic references (no line numbers)?
 - [ ] `AGENTS.md` `Last Updated` date current?

--- a/.agents/skills/finpilot-templates/SKILL.md
+++ b/.agents/skills/finpilot-templates/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   Template initialization, fork setup, renaming conventions, and the
   seven files that must be updated when creating a new image from finpilot.
   Use when initializing a fork, updating AGENTS.md, or documenting setup.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Templates & Fork Setup
@@ -19,8 +17,8 @@ metadata:
 
 ## When NOT to Use
 
-- Build system changes — see `finpilot-build.md`
-- CI workflow changes — see `finpilot-ci.md`
+- Build system changes — use `finpilot-build`
+- CI workflow changes — use `finpilot-ci`
 
 ## Core Process: Creating a New Fork
 
@@ -110,7 +108,7 @@ Static-key signing (`SIGNING_SECRET`) is not supported by this template.
 - Fork repo still has `finpilot` in `clean.yml` (image cleanup will target wrong package)
 - `cosign.pub` placeholder file added to a fork
 - AGENTS.md referencing line numbers instead of semantic identifiers
-- `## Start here` section removed or not pointing to skill files
+- `## Start here` section removed or not routing tasks to Agent Skills
 - `RENOVATE_TOKEN` not set but Renovate workflow is enabled (fails silently on first run)
 
 ## Verification

--- a/.agents/skills/finpilot-troubleshooting/SKILL.md
+++ b/.agents/skills/finpilot-troubleshooting/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   Consolidated symptom-cause-fix table for finpilot. Covers local build failures,
   CI failures, runtime issues, Renovate problems, COPR persistence, and ujust
   command not found. Use when something is broken and you need a quick diagnosis.
-metadata:
-  context7-sources: []
 ---
 
 # finpilot Troubleshooting
@@ -21,9 +19,9 @@ metadata:
 
 ## When NOT to Use
 
-- You are still setting up the fork for the first time — see `finpilot-onboarding.md`
-- You are deciding where to add a package — see `finpilot-packages.md`
-- You need to plan ongoing maintenance — see `finpilot-maintain.md`
+- You are still setting up the fork for the first time — use `finpilot-onboarding`
+- You are deciding where to add a package — use `finpilot-packages`
+- You need to plan ongoing maintenance — use `finpilot-maintain`
 
 ## Core Process
 

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -4,7 +4,7 @@
 
 ### 1. Rename Template
 
-- [ ] Update `finpilot` to your name in **7 files** (see `.agents/skills/finpilot-templates.md`):
+- [ ] Update `finpilot` to your name in **7 files** (use the `finpilot-templates` skill):
   1. `Containerfile` — `ARG IMAGE_NAME` and `ARG IMAGE_VENDOR`
   2. `Justfile` — `export IMAGE_NAME`
   3. `README.md` — title
@@ -13,7 +13,7 @@
   6. `.github/workflows/clean.yml` — `packages`
   7. `iso/iso.toml` — bootc switch URL
 
-**Agent skill:** `finpilot-templates.md` (rename rules), `finpilot-onboarding.md` (fork bootstrap)
+**Agent skills:** `finpilot-templates` (rename rules), `finpilot-onboarding` (fork bootstrap)
 
 ### 2. Enable GitHub Actions
 
@@ -43,16 +43,16 @@ git push origin main
   - Enable "Require branches to be up to date before merging"
 - [ ] Renovate will create a PR to pin your GitHub Actions to SHAs
 
-**Agent skill:** `finpilot-onboarding.md` (branch protection), `finpilot-ci.md` (Renovate config)
+**Agent skills:** `finpilot-onboarding` (branch protection), `finpilot-ci` (Renovate config)
 
 ### 5. Add "What Makes this Raptor Different" to README
 
 - [ ] Open `README.md`
-- [ ] Paste the raptor section template (see README or `.agents/skills/finpilot-onboarding.md`)
+- [ ] Paste the raptor section template (see README or use the `finpilot-onboarding` skill)
 - [ ] Fill in placeholders with your planned customizations
 - [ ] Update the `*Last updated: [date]*` timestamp
 
-**Agent skill:** `finpilot-onboarding.md` (raptor section), `finpilot-maintain.md` (maintenance requirement)
+**Agent skills:** `finpilot-onboarding` (raptor section), `finpilot-maintain` (maintenance requirement)
 
 ### 6. Deploy
 
@@ -72,7 +72,7 @@ This template uses keyless OIDC signing — no keys or secrets are required.
 - [ ] Uncomment the `Sign and publish` step
 - [ ] Commit and push (via PR to `main`)
 
-**Agent skill:** `finpilot-templates.md` (signing setup)
+**Agent skill:** `finpilot-templates` (signing setup)
 
 ## Agent Handoff Reference
 
@@ -80,10 +80,10 @@ Which skill to load for each checklist block above:
 
 | Checklist step                        | Skill                                             |
 | ------------------------------------- | ------------------------------------------------- |
-| Rename (step 1)                       | `finpilot-templates.md`, `finpilot-onboarding.md` |
-| Enable Actions (step 2)               | `finpilot-onboarding.md`                          |
-| Renovate + branch protection (step 4) | `finpilot-onboarding.md`, `finpilot-ci.md`        |
-| Raptor section (step 5)               | `finpilot-onboarding.md`, `finpilot-maintain.md`  |
-| Signing (optional)                    | `finpilot-templates.md`                           |
+| Rename (step 1)                       | `finpilot-templates`, `finpilot-onboarding` |
+| Enable Actions (step 2)               | `finpilot-onboarding`                       |
+| Renovate + branch protection (step 4) | `finpilot-onboarding`, `finpilot-ci`         |
+| Raptor section (step 5)               | `finpilot-onboarding`, `finpilot-maintain`   |
+| Signing (optional)                    | `finpilot-templates`                        |
 
-**Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required per `.agents/skills/finpilot-maintain.md`.
+**Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required by the `finpilot-maintain` skill.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Use @projectbluefin/finpilot as a template, name the OS the repository name. Ens
 
 **Phase 2 — Customize:**
 
-1. Read `.agents/skills/finpilot-packages.md` and add your first system package + first Flatpak/Brew entry
+1. Use the `finpilot-packages` skill and add your first system package + first Flatpak/Brew entry
 2. Update the README "What Makes this Raptor Different" section
 3. Test locally with `just build && just build-qcow2 && just run-vm-qcow2`
 4. Open a PR and merge once `validate` passes
@@ -19,4 +19,4 @@ Use @projectbluefin/finpilot as a template, name the OS the repository name. Ens
 
 1. Enable keyless signing by uncommenting the step in `.github/workflows/build-image.yml`
 2. Verify with: `cosign verify --certificate-identity-regexp="https://github.com/USER/REPO/.github/workflows/" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" ghcr.io/USER/REPO:stable`
-3. Review `.agents/skills/finpilot-maintain.md` for ongoing maintenance schedule
+3. Use the `finpilot-maintain` skill for the ongoing maintenance schedule

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,13 @@ Task-specific instructions are Agent Skills under
 `.agents/skills/<skill-name>/SKILL.md`. Agents discover them automatically from
 their descriptions. Use the matching skill before changing behavior; for an
 unfamiliar multi-phase task, start with `finpilot-overview`, continue with the
-domain skill, and finish with `finpilot-pr-checklist`.
+domain skill, and finish with `finpilot-pr-checklist`. Not sure which skill
+fits? Load `finpilot-router` — it owns the routing table.
 
-- `finpilot-overview` — architecture, repo layout, task router
-- `finpilot-onboarding` — fork bootstrap: rename, Actions, token, first build
-- `finpilot-templates` — template initialization and rename rules
+- `finpilot-router` — task routing: which skill covers what
+- `finpilot-overview` — architecture and repo layout
+- `finpilot-onboarding` — fork bootstrap: rename, Actions, token, first build, raptor section
+- `finpilot-templates` — rename rules, image identity ARGs, signing setup
 - `finpilot-packages` — decision tree (dnf5 vs Brew vs Flatpak)
 - `finpilot-custom` — Brewfiles, Flatpaks, ujust rules
 - `finpilot-build` — Containerfile, Justfile, build scripts
@@ -19,21 +21,6 @@ domain skill, and finish with `finpilot-pr-checklist`.
 - `finpilot-troubleshooting` — symptom → cause → fix
 - `finpilot-pr-checklist` — PR gates by change type
 - `finpilot-examples` — runnable examples and activation patterns
-
-### Task Router
-
-| I need to…                                     | Load                                      |
-| ---------------------------------------------- | ----------------------------------------- |
-| Bootstrap a new fork                           | `finpilot-onboarding`                  |
-| Add/remove a package                           | `finpilot-packages`                    |
-| Change Brewfiles, Flatpaks, or ujust           | `finpilot-custom`                      |
-| Change Containerfile, Justfile, or build/\*.sh | `finpilot-build`                       |
-| Fix CI or Renovate                             | `finpilot-ci` / `finpilot-maintain`    |
-| Open a PR                                      | `finpilot-pr-checklist`                |
-| Debug a build or deploy failure                | `finpilot-troubleshooting`             |
-| Follow a worked example                        | `finpilot-examples`                    |
-| Initialize/ rename this template               | `finpilot-templates`                   |
-| Orient to repo architecture                    | `finpilot-overview`                    |
 
 ## CRITICAL: GitHub API Usage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,33 +2,38 @@
 
 ## Start here
 
-Read the repo skill docs before changing behavior:
+Task-specific instructions are Agent Skills under
+`.agents/skills/<skill-name>/SKILL.md`. Agents discover them automatically from
+their descriptions. Use the matching skill before changing behavior; for an
+unfamiliar multi-phase task, start with `finpilot-overview`, continue with the
+domain skill, and finish with `finpilot-pr-checklist`.
 
-- `.agents/skills/finpilot-overview.md` — architecture, repo layout, task router
-- `.agents/skills/finpilot-onboarding.md` — fork bootstrap: rename, Actions, token, first build
-- `.agents/skills/finpilot-packages.md` — decision tree (dnf5 vs Brew vs Flatpak)
-- `.agents/skills/finpilot-custom.md` — Brewfiles, Flatpaks, ujust rules
-- `.agents/skills/finpilot-build.md` — Containerfile, Justfile, build scripts
-- `.agents/skills/finpilot-ci.md` — GitHub Actions workflows, composite actions, Renovate
-- `.agents/skills/finpilot-maintain.md` — ongoing: Renovate PRs, signing, local test loop
-- `.agents/skills/finpilot-troubleshooting.md` — symptom → cause → fix
-- `.agents/skills/finpilot-pr-checklist.md` — PR gates by change type
-- `.agents/skills/finpilot-examples.md` — runnable examples and activation patterns
+- `finpilot-overview` — architecture, repo layout, task router
+- `finpilot-onboarding` — fork bootstrap: rename, Actions, token, first build
+- `finpilot-templates` — template initialization and rename rules
+- `finpilot-packages` — decision tree (dnf5 vs Brew vs Flatpak)
+- `finpilot-custom` — Brewfiles, Flatpaks, ujust rules
+- `finpilot-build` — Containerfile, Justfile, build scripts
+- `finpilot-ci` — GitHub Actions workflows, composite actions, Renovate
+- `finpilot-maintain` — ongoing: Renovate PRs, signing, local test loop
+- `finpilot-troubleshooting` — symptom → cause → fix
+- `finpilot-pr-checklist` — PR gates by change type
+- `finpilot-examples` — runnable examples and activation patterns
 
 ### Task Router
 
 | I need to…                                     | Load                                      |
 | ---------------------------------------------- | ----------------------------------------- |
-| Bootstrap a new fork                           | `finpilot-onboarding.md`                  |
-| Add/remove a package                           | `finpilot-packages.md`                    |
-| Change Brewfiles, Flatpaks, or ujust           | `finpilot-custom.md`                      |
-| Change Containerfile, Justfile, or build/\*.sh | `finpilot-build.md`                       |
-| Fix CI or Renovate                             | `finpilot-ci.md` / `finpilot-maintain.md` |
-| Open a PR                                      | `finpilot-pr-checklist.md`                |
-| Debug a build or deploy failure                | `finpilot-troubleshooting.md`             |
-| Follow a worked example                        | `finpilot-examples.md`                    |
-| Initialize/ rename this template               | `finpilot-templates.md`                   |
-| Orient to repo architecture                    | `finpilot-overview.md`                    |
+| Bootstrap a new fork                           | `finpilot-onboarding`                  |
+| Add/remove a package                           | `finpilot-packages`                    |
+| Change Brewfiles, Flatpaks, or ujust           | `finpilot-custom`                      |
+| Change Containerfile, Justfile, or build/\*.sh | `finpilot-build`                       |
+| Fix CI or Renovate                             | `finpilot-ci` / `finpilot-maintain`    |
+| Open a PR                                      | `finpilot-pr-checklist`                |
+| Debug a build or deploy failure                | `finpilot-troubleshooting`             |
+| Follow a worked example                        | `finpilot-examples`                    |
+| Initialize/ rename this template               | `finpilot-templates`                   |
+| Orient to repo architecture                    | `finpilot-overview`                    |
 
 ## CRITICAL: GitHub API Usage
 

--- a/README.md
+++ b/README.md
@@ -308,15 +308,6 @@ Your workflow will:
 - Sign all images using keyless OIDC signing
 - Provide cryptographic proof of authenticity via SLSA build provenance attestation
 
-Users can verify your images with:
-
-```bash
-cosign verify \
-  --certificate-identity-regexp="https://github.com/your-username/your-repo-name/.github/workflows/" \
-  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  ghcr.io/your-username/your-repo-name:stable
-```
-
 ## Detailed Guides
 
 - [Homebrew/Brewfiles](custom/brew/README.md) - Runtime package management

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This template works best with **phased prompts** that let Copilot bootstrap your
 Use this prompt first to get your fork building:
 
 ```
-Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repository. Read `.agents/skills/finpilot-onboarding.md` first, then:
+Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repository. Use the `finpilot-onboarding` skill first, then:
 1. Rename `finpilot` in the 7 required files
 2. Enable GitHub Actions and set RENOVATE_TOKEN (repo + workflow scopes)
 3. Configure branch protection for `main` with `validate` as a required status check
@@ -60,7 +60,7 @@ Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repo
 Once the first build is green, use this prompt to add packages:
 
 ```
-Read `.agents/skills/finpilot-packages.md` and `.agents/skills/finpilot-custom.md`, then:
+Use the `finpilot-packages` and `finpilot-custom` skills, then:
 1. Add one system package to the image in `build/10-build.sh`
 2. Add one CLI tool to `custom/brew/default.Brewfile`
 3. Add one GUI app to `custom/flatpaks/default.preinstall`
@@ -75,10 +75,10 @@ Read `.agents/skills/finpilot-packages.md` and `.agents/skills/finpilot-custom.m
 When you are ready for production, use this prompt to harden the setup:
 
 ```
-Read `.agents/skills/finpilot-maintain.md` and `.agents/skills/finpilot-ci.md`, then:
+Use the `finpilot-maintain` and `finpilot-ci` skills, then:
 1. Enable keyless image signing by uncommenting the step in `.github/workflows/build-image.yml`
 2. Verify the cosign command works: cosign verify --certificate-identity-regexp="https://github.com/USER/REPO/.github/workflows/" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" ghcr.io/USER/REPO:stable
-3. Review the maintenance schedule in `finpilot-maintain.md`
+3. Follow the maintenance schedule in the `finpilot-maintain` skill
 ```
 
 ## What's Included

--- a/custom/ujust/custom-apps.just
+++ b/custom/ujust/custom-apps.just
@@ -3,8 +3,8 @@
 ### custom-apps.just
 ####################
 ## Example application installation commands
-## See .agents/skills/finpilot-custom.md for runtime layer guidance
-## See .agents/skills/finpilot-examples.md for activation patterns
+## See .agents/skills/finpilot-custom/SKILL.md for runtime layer guidance
+## See .agents/skills/finpilot-examples/SKILL.md for activation patterns
 
 # Install default applications via Homebrew
 [group('Apps')]

--- a/docs/skills/finpilot-build.md
+++ b/docs/skills/finpilot-build.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-build.md
+../../.agents/skills/finpilot-build/SKILL.md

--- a/docs/skills/finpilot-ci.md
+++ b/docs/skills/finpilot-ci.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-ci.md
+../../.agents/skills/finpilot-ci/SKILL.md

--- a/docs/skills/finpilot-custom.md
+++ b/docs/skills/finpilot-custom.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-custom.md
+../../.agents/skills/finpilot-custom/SKILL.md

--- a/docs/skills/finpilot-examples.md
+++ b/docs/skills/finpilot-examples.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-examples.md
+../../.agents/skills/finpilot-examples/SKILL.md

--- a/docs/skills/finpilot-maintain.md
+++ b/docs/skills/finpilot-maintain.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-maintain.md
+../../.agents/skills/finpilot-maintain/SKILL.md

--- a/docs/skills/finpilot-onboarding.md
+++ b/docs/skills/finpilot-onboarding.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-onboarding.md
+../../.agents/skills/finpilot-onboarding/SKILL.md

--- a/docs/skills/finpilot-overview.md
+++ b/docs/skills/finpilot-overview.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-overview.md
+../../.agents/skills/finpilot-overview/SKILL.md

--- a/docs/skills/finpilot-packages.md
+++ b/docs/skills/finpilot-packages.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-packages.md
+../../.agents/skills/finpilot-packages/SKILL.md

--- a/docs/skills/finpilot-pr-checklist.md
+++ b/docs/skills/finpilot-pr-checklist.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-pr-checklist.md
+../../.agents/skills/finpilot-pr-checklist/SKILL.md

--- a/docs/skills/finpilot-router.md
+++ b/docs/skills/finpilot-router.md
@@ -1,0 +1,1 @@
+../../.agents/skills/finpilot-router/SKILL.md

--- a/docs/skills/finpilot-templates.md
+++ b/docs/skills/finpilot-templates.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-templates.md
+../../.agents/skills/finpilot-templates/SKILL.md

--- a/docs/skills/finpilot-troubleshooting.md
+++ b/docs/skills/finpilot-troubleshooting.md
@@ -1,1 +1,1 @@
-../../.agents/skills/finpilot-troubleshooting.md
+../../.agents/skills/finpilot-troubleshooting/SKILL.md


### PR DESCRIPTION
## Summary

- convert all 11 task guides to the canonical `.agents/skills/<skill-name>/SKILL.md` layout so compatible agents discover them automatically
- route agent prompts and repository instructions by skill name, including the overview → domain → PR-checklist sequence
- preserve the existing human-facing `docs/skills/*.md` links and remove invalid empty metadata from skill frontmatter

## Validation

- `uvx --from skills-ref agentskills validate <skill>` for all 11 skills
- `uvx pre-commit run --all-files`
- `just --list`
- `just check`
- `git diff --check`

Closes #56
