### PR TITLE
fix(ci): simplify rechunking enablement

### DIFF
--- a/.agents/skills/finpilot-ci.md
+++ b/.agents/skills/finpilot-ci.md
@@ -56,6 +56,25 @@ uses: projectbluefin/actions/bootc-build/setup-runner@<sha> # v1
 
 The SHA comment (`# v1`) is for human readability only — Renovate ignores it.
 
+## Rechunking
+
+Set `ENABLE_RECHUNKING: "true"` in `build-image.yml` to enable the existing
+`bootc-build/chunka` step. Keep the action active behind the feature flag rather
+than commenting it out so Renovate continues to update its SHA.
+
+The action is OCI-native and does not use `/usr/libexec/bootc-base-imagectl`.
+Finpilot's default Fedora Silverblue image follows the RPM path, where chunkah
+discovers components from the RPM database.
+
+Rechunking is not a drop-in switch after replacing the default base with a
+BuildStream-produced image. Those images require a generated `xattr-manifest`
+because BuildStream strips component xattrs during OCI export.
+
+Package cadence optimization is optional. `bootc-build/apply-pkg-intervals`
+requires a maintained `files/pkg-intervals.tsv`; the reusable cadence workflow
+also requires GitHub App credentials. Do not present either as a prerequisite
+for basic rechunking.
+
 ## Adding a New Tool (e.g., jq, cosign)
 
 Always pin to a specific version with a Renovate tracking comment:

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -74,6 +74,17 @@ This template uses keyless OIDC signing — no keys or secrets are required.
 
 **Agent skill:** `finpilot-templates.md` (signing setup)
 
+### Enable Rechunking (Optional)
+
+- [ ] Edit `.github/workflows/build-image.yml`
+- [ ] Set `ENABLE_RECHUNKING: "true"`
+- [ ] Keep the default `RECHUNK_MAX_LAYERS: "128"` unless you have measured a reason to change it
+- [ ] Confirm a publish build completes before deploying the new image
+
+The current OCI-native chunkah action does not use `/usr/libexec/bootc-base-imagectl`. Package cadence classification is a separate advanced setup and is not required for basic rechunking.
+
+**Agent skill:** `finpilot-ci.md` (rechunking compatibility and workflow setup)
+
 ## Agent Handoff Reference
 
 Which skill to load for each checklist block above:
@@ -85,5 +96,6 @@ Which skill to load for each checklist block above:
 | Renovate + branch protection (step 4) | `finpilot-onboarding.md`, `finpilot-ci.md`        |
 | Raptor section (step 5)               | `finpilot-onboarding.md`, `finpilot-maintain.md`  |
 | Signing (optional)                    | `finpilot-templates.md`                           |
+| Rechunking (optional)                 | `finpilot-ci.md`                                  |
 
 **Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required per `.agents/skills/finpilot-maintain.md`.

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -34,6 +34,8 @@ env:
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
   DEFAULT_TAG: "stable"
   REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
+  ENABLE_RECHUNKING: "false"
+  RECHUNK_MAX_LAYERS: "128"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -143,23 +145,15 @@ jobs:
           allow-write: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
           cache-bust: ${{ hashFiles('**/Containerfile') }}
 
-      # OPTIONAL: Rechunking (OCI-native, no rpm-ostree)
-      # Rechunking improves OTA delta performance by reorganizing layers.
-      # Uncomment the step below to enable it. Renovate will keep the action
-      # pinned and up to date automatically once it is uncommented.
-      #
-      # For optimal layer grouping (packages sorted by update cadence), also add
-      # the bootc-build/apply-pkg-intervals step before rechunking and create a
-      # .github/workflows/pkg-cadence.yml workflow. See:
-      #   https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka
-      #   https://github.com/projectbluefin/actions/tree/main/bootc-build/apply-pkg-intervals
-      # - name: Rechunk image
-      #   if: github.event_name != 'pull_request'
-      #   id: rechunk-image
-      #   uses: projectbluefin/actions/bootc-build/chunka@6231015b336556d2ff0adc1d1e59514bf19dcb42 # v1
-      #   with:
-      #     source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
-      #     max-layers: 128
+      # OPTIONAL: Set ENABLE_RECHUNKING to "true" above to optimize OTA deltas.
+      # This uses OCI-native chunkah and does not require bootc-base-imagectl.
+      - name: Rechunk image
+        if: env.ENABLE_RECHUNKING == 'true' && github.event_name != 'pull_request'
+        id: rechunk-image
+        uses: projectbluefin/actions/bootc-build/chunka@c3ffb5dd594f4a363298bacc7ad4cfe18457fa97 # v1
+        with:
+          source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
+          max-layers: ${{ env.RECHUNK_MAX_LAYERS }}
 
       - name: Tag images
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -264,41 +264,35 @@ Ready to take your custom OS to production? Enable these features for enhanced s
 
 - [ ] **Enable Image Rechunking** (Recommended)
   - Optimizes bootc image layers for better update performance
-  - Reduces update sizes by 5-10x when combined with package cadence data
   - Improves download resumability with evenly sized layers
-  - To enable:
-    1. Edit `.github/workflows/build-image.yml`
-    2. Find the "OPTIONAL: Rechunking" section
-    3. Uncomment the `bootc-build/chunka` step
-  - For optimal results, also add `bootc-build/apply-pkg-intervals` and a `pkg-cadence.yml` workflow
+  - Set `ENABLE_RECHUNKING: "true"` in `.github/workflows/build-image.yml`
+  - Uses OCI-native chunkah; `/usr/libexec/bootc-base-imagectl` is not required
   - Status: **Not enabled by default** (optional optimization)
 
 #### Adding Image Rechunking
 
-After building your bootc image, add a rechunk step before pushing to the registry. The template ships with a commented `bootc-build/chunka` step in `.github/workflows/build-image.yml`:
+The old rechunking recipe used `/usr/libexec/bootc-base-imagectl`, which is absent from many Universal Blue images. Do not copy that recipe or install a legacy rechunker: its layer format is not a safe migration path to the current implementation.
+
+Finpilot instead uses the OCI-native [`bootc-build/chunka`](https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka) action. The action runs chunkah from a pinned container and replaces the locally built image before the existing tag and push steps. The default Fedora Silverblue-based finpilot image is RPM-based, so chunkah can discover components from its RPM database without `bootc-base-imagectl`.
+
+To enable it, change the workflow environment value:
 
 ```yaml
-- name: Rechunk image
-  if: github.event_name != 'pull_request'
-  id: rechunk-image
-  uses: projectbluefin/actions/bootc-build/chunka@6231015b336556d2ff0adc1d1e59514bf19dcb42 # v1
-  with:
-    source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
-    max-layers: 128
+env:
+  ENABLE_RECHUNKING: "true"
+  RECHUNK_MAX_LAYERS: "128"
 ```
 
-This uses [chunkah](https://github.com/coreos/chunkah) to reorganize OCI layers without rpm-ostree. Renovate will keep the action updated once it is uncommented.
+Rechunking runs only for publish builds, not pull requests. It requires additional runner time and temporary storage. Keep `ENABLE_RECHUNKING` set to `"false"` if those costs are more important than smaller OTA deltas.
 
-**Parameters:**
+**Custom base images:** This switch is supported for the template's default RPM-based image. BuildStream-produced images strip the component xattrs chunkah needs and require an `xattr-manifest`; changing to one of those images is not a one-line setup. See the action's `xattr-manifest` input before replacing the default base.
 
-- `max-layers`: Maximum number of layers for the rechunked image (128 is a typical bootc default)
-- `source-image`: Local image reference to rechunk
-
-**For optimal OTA deltas**, also add `bootc-build/apply-pkg-intervals` before the rechunk step and create a `.github/workflows/pkg-cadence.yml` workflow that calls `projectbluefin/actions/.github/workflows/reusable-pkg-cadence.yml@v1`. This groups packages by update cadence (weekly, monthly, quarterly, yearly) so a typical update only downloads layers that actually changed. Without it, chunkah still works but uses default layer grouping.
+**Optional package cadence:** Basic rechunking does not require package cadence data. Advanced deployments can run [`bootc-build/apply-pkg-intervals`](https://github.com/projectbluefin/actions/tree/main/bootc-build/apply-pkg-intervals) before rechunking and maintain `files/pkg-intervals.tsv` with the reusable package-cadence workflow. That workflow requires a repository GitHub App ID and private key, so configure it separately rather than treating it as part of basic enablement.
 
 **References:**
 
-- [CoreOS rpm-ostree build-chunked-oci documentation](https://coreos.github.io/rpm-ostree/build-chunked-oci/)
+- [chunkah](https://github.com/coreos/chunkah)
+- [projectbluefin/actions rechunking](https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka)
 - [bootc documentation](https://containers.github.io/bootc/)
 
 ### After Enabling Production Features

--- a/build/10-build.sh
+++ b/build/10-build.sh
@@ -16,15 +16,6 @@ source /ctx/build/copr-helpers.sh
 # Enable nullglob for all glob operations to prevent failures on empty matches
 shopt -s nullglob
 
-echo "::group:: Copy Bluefin Config from Common"
-
-# Copy just files from @projectbluefin/common (includes 00-entry.just which imports 60-custom.just)
-mkdir -p /usr/share/ublue-os/just/
-shopt -s nullglob
-cp -r /ctx/oci/common/bluefin/usr/share/ublue-os/just/* /usr/share/ublue-os/just/
-shopt -u nullglob
-
-echo "::endgroup::"
 
 echo "::group:: Overlay Brew Integration Files"
 
@@ -40,6 +31,7 @@ mkdir -p /usr/share/ublue-os/homebrew/
 cp /ctx/custom/brew/*.Brewfile /usr/share/ublue-os/homebrew/
 
 # Consolidate Just Files
+mkdir -p /usr/share/ublue-os/just/
 find /ctx/custom/ujust -iname '*.just' -exec printf "\n\n" \; -exec cat {} \; >>/usr/share/ublue-os/just/60-custom.just
 
 # Copy Flatpak preinstall files


### PR DESCRIPTION
Closes #54

## Summary

- Replace the commented, stale rechunk action with an active Renovate-managed step gated by `ENABLE_RECHUNKING`
- Make basic rechunking a one-line `false` to `true` workflow environment change
- Document that chunkah does not require `/usr/libexec/bootc-base-imagectl` and supports finpilot's default RPM-based image
- Separate basic rechunking from BuildStream `xattr-manifest` and package-cadence GitHub App requirements
- Update `README.md`, `.github/SETUP_CHECKLIST.md`, and `.agents/skills/finpilot-ci.md`

## Validation

- `just check`
- `git diff --check`