### PR TITLE
ci: add testing and stable promotion workflow

### DIFF
--- a/.agents/skills/finpilot-ci/SKILL.md
+++ b/.agents/skills/finpilot-ci/SKILL.md
@@ -33,7 +33,7 @@ description: >-
 
 | File                     | Trigger                           | Purpose                                              |
 | ------------------------ | --------------------------------- | ---------------------------------------------------- |
-| `build-image.yml`        | push main, schedule, manual       | Build + push `:stable` via `projectbluefin/actions`  |
+| `build-image.yml`        | PR/push main + stable, merge group, manual | Build PRs; publish `:stable-testing` or `:stable` |
 | `pr-validation.yml`      | PR → main                         | shellcheck + hadolint + pre-commit via `validate-pr` |
 | `renovate.yml`           | schedule 6h, push renovate config | Self-hosted Renovate runner                          |
 | `clean.yml`              | schedule weekly                   | Delete GHCR images older than 90 days                |
@@ -41,6 +41,14 @@ description: >-
 | `validate-flatpaks.yml`  | PR paths: `custom/flatpaks/**`    | Flathub app ID existence check                       |
 | `validate-justfiles.yml` | PR paths: `Justfile`              | `just --list` syntax check                           |
 | `validate-renovate.yml`  | PR paths: `.github/renovate.json` | `renovate-config-validator`                          |
+
+## Branch Promotion and Tags
+
+- `main` is the testing branch and publishes `:stable-testing`.
+- `stable` is the production branch and publishes `:stable`.
+- `.github/pull.yml` configures pull[bot] to promote `main` to `stable`.
+- The shared `generate-tags` action uses a `testing` stream internally; the workflow normalizes those aliases to `stable-testing` before publishing.
+- Never add branch-specific changes directly to `stable`; its history is hard-reset from `main` during promotion.
 
 ## Composite Action Pins
 

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -4,57 +4,100 @@
 
 ### 1. Rename Template
 
-- [ ] Update `finpilot` to your name in **7 files** (use the `finpilot-templates` skill):
-  1. `Containerfile` — `ARG IMAGE_NAME` and `ARG IMAGE_VENDOR`
-  2. `Justfile` — `export IMAGE_NAME`
-  3. `README.md` — title
-  4. `artifacthub-repo.yml` — `repositoryID`
-  5. `custom/ujust/README.md` — bootc switch example
-  6. `.github/workflows/clean.yml` — `packages`
-  7. `iso/iso.toml` — bootc switch URL
+- [ ] Update `finpilot` to your name in **7 files** (see `.agents/skills/finpilot-templates.md`):
+  1. `Containerfile` - `ARG IMAGE_NAME` and `ARG IMAGE_VENDOR`
+  2. `Justfile` - `export IMAGE_NAME`
+  3. `README.md` - title
+  4. `artifacthub-repo.yml` - `repositoryID`
+  5. `custom/ujust/README.md` - bootc switch example
+  6. `.github/workflows/clean.yml` - `packages`
+  7. `iso/iso.toml` - bootc switch URL
 
-**Agent skills:** `finpilot-templates` (rename rules), `finpilot-onboarding` (fork bootstrap)
+**Agent skill:** `finpilot-templates.md` (rename rules), `finpilot-onboarding.md` (fork bootstrap)
 
 ### 2. Enable GitHub Actions
 
-- [ ] Settings → Actions → General → Enable workflows
+- [ ] Settings -> Actions -> General -> Enable workflows
 - [ ] Set "Read and write permissions"
 
-### 3. First Push
+### 3. Configure Testing and Production Branches
+
+Create `stable` as an exact copy of `main`, then return to `main`:
 
 ```bash
-git add .
-git commit -m "feat: initial customization"
-git push origin main
+git switch main
+git switch -c stable
+git push --set-upstream origin stable
+git switch main
 ```
 
-### 4. Enable Renovate (Required)
+- [ ] Replace each `OWNER` placeholder in `.github/pull.yml` with your GitHub username
+- [ ] Install the [pull GitHub App](https://github.com/apps/pull) for this repository
+- [ ] Validate the configuration at `https://pull.git.ci/check/YOUR_USERNAME/YOUR_REPO`
+- [ ] Never commit directly to `stable`; pull[bot] must keep it synchronized with `main`
 
-- [ ] Create a **Classic PAT** (Settings → Developer settings → Personal access tokens → Tokens (classic))
+The resulting delivery flow is:
+
+```text
+feature branch
+      |
+      v
+PR -> main -> ghcr.io/OWNER/REPO:stable-testing
+             |
+             v
+       pull[bot] promotion PR
+             |
+             v
+          stable -> ghcr.io/OWNER/REPO:stable
+```
+
+### 4. First Change
+
+Open a pull request targeting `main`. After it merges:
+
+1. Verify the `:stable-testing` image.
+2. Wait for pull[bot] to open the `main` -> `stable` promotion PR.
+3. Approve and merge the promotion PR.
+4. Verify the `:stable` image.
+
+### 5. Enable Renovate (Required)
+
+- [ ] Create a **Classic PAT** (Settings -> Developer settings -> Personal access tokens -> Tokens (classic))
   - Scopes: `repo` (full control) + `workflow` (update workflows)
-- [ ] Add the token as repository secret **`RENOVATE_TOKEN`** (Settings → Secrets and variables → Actions)
-- [ ] Enable **Settings → General → Pull Requests → Allow auto-merge**
+- [ ] Add the token as repository secret **`RENOVATE_TOKEN`** (Settings -> Secrets and variables -> Actions)
+- [ ] Enable **Settings -> General -> Pull Requests -> Allow auto-merge**
 - [ ] Configure branch protection for `main`:
-  - Settings → Branches → Add rule
+  - Settings -> Branches -> Add rule
   - Set **Branch name pattern** to `main`
   - Enable "Require a pull request before merging"
   - Enable "Require status checks to pass before merging"
   - Add `validate` as a required status check
   - Enable "Require branches to be up to date before merging"
-- [ ] Renovate will create a PR to pin your GitHub Actions to SHAs
+- [ ] Protect `stable` from direct pushes and require pull requests and successful checks
 
-**Agent skills:** `finpilot-onboarding` (branch protection), `finpilot-ci` (Renovate config)
+Renovate targets `main`; approved changes reach `stable` through the same promotion flow.
 
-### 5. Add "What Makes this Raptor Different" to README
+**Agent skill:** `finpilot-onboarding.md` (branch protection), `finpilot-ci.md` (Renovate config)
+
+### 6. Add "What Makes this Raptor Different" to README
 
 - [ ] Open `README.md`
-- [ ] Paste the raptor section template (see README or use the `finpilot-onboarding` skill)
+- [ ] Paste the raptor section template (see README or `.agents/skills/finpilot-onboarding.md`)
 - [ ] Fill in placeholders with your planned customizations
 - [ ] Update the `*Last updated: [date]*` timestamp
 
-**Agent skills:** `finpilot-onboarding` (raptor section), `finpilot-maintain` (maintenance requirement)
+**Agent skill:** `finpilot-onboarding.md` (raptor section), `finpilot-maintain.md` (maintenance requirement)
 
-### 6. Deploy
+### 7. Deploy
+
+Test the candidate image from `main`:
+
+```bash
+sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable-testing
+sudo systemctl reboot
+```
+
+After approving promotion to `stable`, deploy the production image:
 
 ```bash
 sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable
@@ -65,25 +108,36 @@ sudo systemctl reboot
 
 ### Enable Signing (Recommended)
 
-This template uses keyless OIDC signing — no keys or secrets are required.
+This template uses keyless OIDC signing - no keys or secrets are required.
 
 - [ ] Edit `.github/workflows/build-image.yml`
 - [ ] Find the "OPTIONAL: Sign and attest" section
 - [ ] Uncomment the `Sign and publish` step
-- [ ] Commit and push (via PR to `main`)
+- [ ] Commit through a pull request to `main`
 
-**Agent skill:** `finpilot-templates` (signing setup)
+**Agent skill:** `finpilot-templates.md` (signing setup)
+
+### Enable Rechunking (Optional)
+
+- [ ] Edit `.github/workflows/build-image.yml`
+- [ ] Set `ENABLE_RECHUNKING: "true"`
+- [ ] Keep the default `RECHUNK_MAX_LAYERS: "128"` unless you have measured a reason to change it
+- [ ] Confirm a publish build completes before deploying the new image
+
+The current OCI-native chunkah action does not use `/usr/libexec/bootc-base-imagectl`. Package cadence classification is a separate advanced setup and is not required for basic rechunking.
+
+**Agent skill:** `finpilot-ci.md` (rechunking compatibility and workflow setup)
 
 ## Agent Handoff Reference
 
-Which skill to load for each checklist block above:
+| Checklist step | Skill |
+| --- | --- |
+| Rename (step 1) | `finpilot-templates.md`, `finpilot-onboarding.md` |
+| Enable Actions (step 2) | `finpilot-onboarding.md` |
+| Branches and pull[bot] (step 3) | `finpilot-onboarding.md`, `finpilot-ci.md` |
+| Renovate + branch protection (step 5) | `finpilot-onboarding.md`, `finpilot-ci.md` |
+| Raptor section (step 6) | `finpilot-onboarding.md`, `finpilot-maintain.md` |
+| Signing (optional) | `finpilot-templates.md` |
+| Rechunking (optional) | `finpilot-ci.md` |
 
-| Checklist step                        | Skill                                           |
-| ------------------------------------- | ----------------------------------------------- |
-| Rename (step 1)                       | `finpilot-templates`, `finpilot-onboarding`     |
-| Enable Actions (step 2)               | `finpilot-onboarding`                           |
-| Renovate + branch protection (step 4) | `finpilot-onboarding`, `finpilot-ci`            |
-| Raptor section (step 5)               | `finpilot-onboarding`, `finpilot-maintain`      |
-| Signing (optional)                    | `finpilot-templates`                            |
-
-**Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required by the `finpilot-maintain` skill.
+**Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required per `.agents/skills/finpilot-maintain.md`.

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -4,20 +4,20 @@
 
 ### 1. Rename Template
 
-- [ ] Update `finpilot` to your name in **7 files** (see `.agents/skills/finpilot-templates.md`):
-  1. `Containerfile` - `ARG IMAGE_NAME` and `ARG IMAGE_VENDOR`
-  2. `Justfile` - `export IMAGE_NAME`
-  3. `README.md` - title
-  4. `artifacthub-repo.yml` - `repositoryID`
-  5. `custom/ujust/README.md` - bootc switch example
-  6. `.github/workflows/clean.yml` - `packages`
-  7. `iso/iso.toml` - bootc switch URL
+- [ ] Update `finpilot` to your name in **7 files** (see `finpilot-templates`):
+  1. `Containerfile` — `ARG IMAGE_NAME` and `ARG IMAGE_VENDOR`
+  2. `Justfile` — `export IMAGE_NAME`
+  3. `README.md` — title
+  4. `artifacthub-repo.yml` — `repositoryID`
+  5. `custom/ujust/README.md` — bootc switch example
+  6. `.github/workflows/clean.yml` — `packages`
+  7. `iso/iso.toml` — bootc switch URL
 
-**Agent skill:** `finpilot-templates.md` (rename rules), `finpilot-onboarding.md` (fork bootstrap)
+**Agent skill:** `finpilot-templates` (rename rules), `finpilot-onboarding` (fork bootstrap)
 
 ### 2. Enable GitHub Actions
 
-- [ ] Settings -> Actions -> General -> Enable workflows
+- [ ] Settings → Actions → General → Enable workflows
 - [ ] Set "Read and write permissions"
 
 ### 3. Configure Testing and Production Branches
@@ -31,7 +31,7 @@ git push --set-upstream origin stable
 git switch main
 ```
 
-- [ ] Replace each `OWNER` placeholder in `.github/pull.yml` with your GitHub username
+- [ ] Replace `castrojo` in `.github/pull.yml` (`reviewers` and `conflictReviewers`) with your GitHub username
 - [ ] Install the [pull GitHub App](https://github.com/apps/pull) for this repository
 - [ ] Validate the configuration at `https://pull.git.ci/check/YOUR_USERNAME/YOUR_REPO`
 - [ ] Never commit directly to `stable`; pull[bot] must keep it synchronized with `main`
@@ -62,12 +62,12 @@ Open a pull request targeting `main`. After it merges:
 
 ### 5. Enable Renovate (Required)
 
-- [ ] Create a **Classic PAT** (Settings -> Developer settings -> Personal access tokens -> Tokens (classic))
+- [ ] Create a **Classic PAT** (Settings → Developer settings → Personal access tokens → Tokens (classic))
   - Scopes: `repo` (full control) + `workflow` (update workflows)
-- [ ] Add the token as repository secret **`RENOVATE_TOKEN`** (Settings -> Secrets and variables -> Actions)
-- [ ] Enable **Settings -> General -> Pull Requests -> Allow auto-merge**
+- [ ] Add the token as repository secret **`RENOVATE_TOKEN`** (Settings → Secrets and variables → Actions)
+- [ ] Enable **Settings → General → Pull Requests → Allow auto-merge**
 - [ ] Configure branch protection for `main`:
-  - Settings -> Branches -> Add rule
+  - Settings → Branches → Add rule
   - Set **Branch name pattern** to `main`
   - Enable "Require a pull request before merging"
   - Enable "Require status checks to pass before merging"
@@ -77,16 +77,16 @@ Open a pull request targeting `main`. After it merges:
 
 Renovate targets `main`; approved changes reach `stable` through the same promotion flow.
 
-**Agent skill:** `finpilot-onboarding.md` (branch protection), `finpilot-ci.md` (Renovate config)
+**Agent skill:** `finpilot-onboarding` (branch protection), `finpilot-ci` (Renovate config)
 
 ### 6. Add "What Makes this Raptor Different" to README
 
 - [ ] Open `README.md`
-- [ ] Paste the raptor section template (see README or `.agents/skills/finpilot-onboarding.md`)
+- [ ] Paste the raptor section template (see README or `finpilot-onboarding`)
 - [ ] Fill in placeholders with your planned customizations
 - [ ] Update the `*Last updated: [date]*` timestamp
 
-**Agent skill:** `finpilot-onboarding.md` (raptor section), `finpilot-maintain.md` (maintenance requirement)
+**Agent skill:** `finpilot-onboarding` (raptor section), `finpilot-maintain` (maintenance requirement)
 
 ### 7. Deploy
 
@@ -108,36 +108,24 @@ sudo systemctl reboot
 
 ### Enable Signing (Recommended)
 
-This template uses keyless OIDC signing - no keys or secrets are required.
+This template uses keyless OIDC signing — no keys or secrets are required.
 
 - [ ] Edit `.github/workflows/build-image.yml`
 - [ ] Find the "OPTIONAL: Sign and attest" section
 - [ ] Uncomment the `Sign and publish` step
 - [ ] Commit through a pull request to `main`
 
-**Agent skill:** `finpilot-templates.md` (signing setup)
-
-### Enable Rechunking (Optional)
-
-- [ ] Edit `.github/workflows/build-image.yml`
-- [ ] Set `ENABLE_RECHUNKING: "true"`
-- [ ] Keep the default `RECHUNK_MAX_LAYERS: "128"` unless you have measured a reason to change it
-- [ ] Confirm a publish build completes before deploying the new image
-
-The current OCI-native chunkah action does not use `/usr/libexec/bootc-base-imagectl`. Package cadence classification is a separate advanced setup and is not required for basic rechunking.
-
-**Agent skill:** `finpilot-ci.md` (rechunking compatibility and workflow setup)
+**Agent skill:** `finpilot-templates` (signing setup)
 
 ## Agent Handoff Reference
 
 | Checklist step | Skill |
 | --- | --- |
-| Rename (step 1) | `finpilot-templates.md`, `finpilot-onboarding.md` |
-| Enable Actions (step 2) | `finpilot-onboarding.md` |
-| Branches and pull[bot] (step 3) | `finpilot-onboarding.md`, `finpilot-ci.md` |
-| Renovate + branch protection (step 5) | `finpilot-onboarding.md`, `finpilot-ci.md` |
-| Raptor section (step 6) | `finpilot-onboarding.md`, `finpilot-maintain.md` |
-| Signing (optional) | `finpilot-templates.md` |
-| Rechunking (optional) | `finpilot-ci.md` |
+| Rename (step 1) | `finpilot-templates`, `finpilot-onboarding` |
+| Enable Actions (step 2) | `finpilot-onboarding` |
+| Branches and pull[bot] (step 3) | `finpilot-onboarding`, `finpilot-ci` |
+| Renovate + branch protection (step 5) | `finpilot-onboarding`, `finpilot-ci` |
+| Raptor section (step 6) | `finpilot-onboarding`, `finpilot-maintain` |
+| Signing (optional) | `finpilot-templates` |
 
-**Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required per `.agents/skills/finpilot-maintain.md`.
+**Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required per `finpilot-maintain`.

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,12 @@
+version: "1"
+rules:
+  - base: stable
+    upstream: main
+    mergeMethod: hardreset
+    mergeUnstable: false
+    reviewers:
+      - OWNER
+    conflictReviewers:
+      - OWNER
+label: "promotion"
+conflictLabel: "promotion-conflict"

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,3 +1,5 @@
+# pull[bot] promotes tested commits from `main` to `stable`.
+# Forks: replace `castrojo` below with your own GitHub username.
 version: "1"
 rules:
   - base: stable
@@ -5,8 +7,8 @@ rules:
     mergeMethod: hardreset
     mergeUnstable: false
     reviewers:
-      - OWNER
+      - castrojo
     conflictReviewers:
-      - OWNER
+      - castrojo
 label: "promotion"
 conflictLabel: "promotion-conflict"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,22 +1,22 @@
 ---
 name: Build and Push Image
 
-# PR builds are disabled by default to save CI minutes. To enable them, add:
-#   pull_request:
-#     branches:
-#       - main
-#     paths-ignore:
-#       - "**.md"
-#       - ".github/workflows/*validate*.yml"
 on:
-  push:
+  pull_request:
     branches:
       - main
+      - stable
     paths-ignore:
       - "**.md"
       - ".github/workflows/*validate*.yml"
-  schedule:
-    - cron: "05 10 * * *" # 10:05am UTC everyday
+  push:
+    branches:
+      - main
+      - stable
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*validate*.yml"
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -33,7 +33,11 @@ env:
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
   DEFAULT_TAG: "stable"
+  PRODUCTION_BRANCH: "stable"
+  TESTING_BRANCH: "main"
   REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
+  ENABLE_RECHUNKING: "false"
+  RECHUNK_MAX_LAYERS: "128"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -53,8 +57,23 @@ jobs:
     steps:
       - name: Prepare environment
         run: |
-          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
-          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> "${GITHUB_ENV}"
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "${GITHUB_ENV}"
+
+      - name: Determine image tag
+        id: determine-tag
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]]; then
+            echo "DEFAULT_TAG=${DEFAULT_TAG}-testing" >> "${GITHUB_ENV}"
+            echo "TAG_STREAM=testing" >> "${GITHUB_ENV}"
+            echo "Building testing image: ${DEFAULT_TAG}-testing"
+          else
+            echo "TAG_STREAM=${DEFAULT_TAG}" >> "${GITHUB_ENV}"
+            echo "Building production image: ${DEFAULT_TAG}"
+          fi
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -120,7 +139,7 @@ jobs:
         run: |
           VERSION_LABEL=$(sudo podman inspect "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
             --format '{{index .Config.Labels "org.opencontainers.image.version"}}')
-          echo "version=${VERSION_LABEL}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION_LABEL}" >> "${GITHUB_OUTPUT}"
           echo "Version: ${VERSION_LABEL}"
 
       - name: Generate tags
@@ -129,10 +148,44 @@ jobs:
         uses: projectbluefin/actions/bootc-build/generate-tags@c3ffb5dd594f4a363298bacc7ad4cfe18457fa97 # v1
         with:
           base-name: ${{ env.IMAGE_NAME }}
-          stream-name: ${{ env.DEFAULT_TAG }}
+          stream-name: ${{ env.TAG_STREAM }}
           version-label: ${{ steps.version.outputs.version }}
           event-name: ${{ github.event_name }}
           pr-number: ${{ github.event.number }}
+
+      - name: Finalize branch tags
+        if: steps.detect-changes.outputs.should_build == 'true' || github.event_name != 'pull_request'
+        id: branch-tags
+        shell: bash
+        env:
+          GENERATED_TAGS: ${{ steps.generate-tags.outputs.tags }}
+        run: |
+          read -r -a generated_tags <<< "${GENERATED_TAGS}"
+          branch_tags=()
+
+          add_tag() {
+            local candidate="$1"
+            local existing
+            for existing in "${branch_tags[@]}"; do
+              [[ "${existing}" == "${candidate}" ]] && return
+            done
+            branch_tags+=("${candidate}")
+          }
+
+          for tag in "${generated_tags[@]}"; do
+            if [[ "${TAG_STREAM}" == "testing" ]]; then
+              if [[ "${tag}" == testing* ]]; then
+                tag="stable-${tag}"
+              else
+                tag="${tag/-testing-/-stable-testing-}"
+              fi
+            fi
+            add_tag "${tag}"
+          done
+          add_tag "${DEFAULT_TAG}"
+
+          echo "tags=${branch_tags[*]}" >> "${GITHUB_OUTPUT}"
+          echo "default-tag=${DEFAULT_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Save DNF cache
         if: always() && !cancelled() && github.event_name != 'pull_request'
@@ -143,36 +196,28 @@ jobs:
           allow-write: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
           cache-bust: ${{ hashFiles('**/Containerfile') }}
 
-      # OPTIONAL: Rechunking (OCI-native, no rpm-ostree)
-      # Rechunking improves OTA delta performance by reorganizing layers.
-      # Uncomment the step below to enable it. Renovate will keep the action
-      # pinned and up to date automatically once it is uncommented.
-      #
-      # For optimal layer grouping (packages sorted by update cadence), also add
-      # the bootc-build/apply-pkg-intervals step before rechunking and create a
-      # .github/workflows/pkg-cadence.yml workflow. See:
-      #   https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka
-      #   https://github.com/projectbluefin/actions/tree/main/bootc-build/apply-pkg-intervals
-      # - name: Rechunk image
-      #   if: github.event_name != 'pull_request'
-      #   id: rechunk-image
-      #   uses: projectbluefin/actions/bootc-build/chunka@6231015b336556d2ff0adc1d1e59514bf19dcb42 # v1
-      #   with:
-      #     source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
-      #     max-layers: 128
+      # OPTIONAL: Set ENABLE_RECHUNKING to "true" above to optimize OTA deltas.
+      # This uses OCI-native chunkah and does not require bootc-base-imagectl.
+      - name: Rechunk image
+        if: env.ENABLE_RECHUNKING == 'true' && github.event_name != 'pull_request'
+        id: rechunk-image
+        uses: projectbluefin/actions/bootc-build/chunka@c3ffb5dd594f4a363298bacc7ad4cfe18457fa97 # v1
+        with:
+          source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
+          max-layers: ${{ env.RECHUNK_MAX_LAYERS }}
 
       - name: Tag images
         if: github.event_name != 'pull_request'
         shell: bash
         env:
-          ALIAS_TAGS: ${{ steps.generate-tags.outputs.tags }}
+          ALIAS_TAGS: ${{ steps.branch-tags.outputs.tags }}
         run: |
           sudo -E "$(command -v just)" tag-images "${IMAGE_NAME}" \
                           "${DEFAULT_TAG}" \
                           "${ALIAS_TAGS}"
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
@@ -180,13 +225,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GHCR
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         id: push
         uses: projectbluefin/actions/bootc-build/push-image@c3ffb5dd594f4a363298bacc7ad4cfe18457fa97 # v1
         with:
           image-name: ${{ env.IMAGE_NAME }}
-          tags: ${{ steps.generate-tags.outputs.tags }}
-          default-tag: ${{ steps.generate-tags.outputs.default-tag }}
+          tags: ${{ steps.branch-tags.outputs.tags }}
+          default-tag: ${{ steps.branch-tags.outputs.default-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # OPTIONAL: Sign and attest (SLSA Build L2 provenance)

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,6 +17,8 @@ on:
       - "**.md"
       - ".github/workflows/*validate*.yml"
   merge_group:
+  schedule:
+    - cron: "05 10 * * *" # 10:05am UTC everyday
   workflow_dispatch:
 
 permissions:
@@ -36,8 +38,6 @@ env:
   PRODUCTION_BRANCH: "stable"
   TESTING_BRANCH: "main"
   REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
-  ENABLE_RECHUNKING: "false"
-  RECHUNK_MAX_LAYERS: "128"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -196,15 +196,23 @@ jobs:
           allow-write: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
           cache-bust: ${{ hashFiles('**/Containerfile') }}
 
-      # OPTIONAL: Set ENABLE_RECHUNKING to "true" above to optimize OTA deltas.
-      # This uses OCI-native chunkah and does not require bootc-base-imagectl.
-      - name: Rechunk image
-        if: env.ENABLE_RECHUNKING == 'true' && github.event_name != 'pull_request'
-        id: rechunk-image
-        uses: projectbluefin/actions/bootc-build/chunka@c3ffb5dd594f4a363298bacc7ad4cfe18457fa97 # v1
-        with:
-          source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
-          max-layers: ${{ env.RECHUNK_MAX_LAYERS }}
+            # OPTIONAL: Rechunking (OCI-native, no rpm-ostree)
+      # Rechunking improves OTA delta performance by reorganizing layers.
+      # Uncomment the step below to enable it. Renovate will keep the action
+      # pinned and up to date automatically once it is uncommented.
+      #
+      # For optimal layer grouping (packages sorted by update cadence), also add
+      # the bootc-build/apply-pkg-intervals step before rechunking and create a
+      # .github/workflows/pkg-cadence.yml workflow. See:
+      #   https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka
+      #   https://github.com/projectbluefin/actions/tree/main/bootc-build/apply-pkg-intervals
+      # - name: Rechunk image
+      #   if: github.event_name != 'pull_request'
+      #   id: rechunk-image
+      #   uses: projectbluefin/actions/bootc-build/chunka@6231015b336556d2ff0adc1d1e59514bf19dcb42 # v1
+      #   with:
+      #     source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
+      #     max-layers: 128
 
       - name: Tag images
         if: github.event_name != 'pull_request'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,33 +2,13 @@
 
 ## Start here
 
-Read the repo skill docs before changing behavior:
-
-- `.agents/skills/finpilot-overview.md` — architecture, repo layout, task router
-- `.agents/skills/finpilot-onboarding.md` — fork bootstrap: rename, Actions, token, first build
-- `.agents/skills/finpilot-packages.md` — decision tree (dnf5 vs Brew vs Flatpak)
-- `.agents/skills/finpilot-custom.md` — Brewfiles, Flatpaks, ujust rules
-- `.agents/skills/finpilot-build.md` — Containerfile, Justfile, build scripts
-- `.agents/skills/finpilot-ci.md` — GitHub Actions workflows, composite actions, Renovate
-- `.agents/skills/finpilot-maintain.md` — ongoing: Renovate PRs, signing, local test loop
-- `.agents/skills/finpilot-troubleshooting.md` — symptom → cause → fix
-- `.agents/skills/finpilot-pr-checklist.md` — PR gates by change type
-- `.agents/skills/finpilot-examples.md` — runnable examples and activation patterns
-
-### Task Router
-
-| I need to…                                     | Load                                      |
-| ---------------------------------------------- | ----------------------------------------- |
-| Bootstrap a new fork                           | `finpilot-onboarding.md`                  |
-| Add/remove a package                           | `finpilot-packages.md`                    |
-| Change Brewfiles, Flatpaks, or ujust           | `finpilot-custom.md`                      |
-| Change Containerfile, Justfile, or build/\*.sh | `finpilot-build.md`                       |
-| Fix CI or Renovate                             | `finpilot-ci.md` / `finpilot-maintain.md` |
-| Open a PR                                      | `finpilot-pr-checklist.md`                |
-| Debug a build or deploy failure                | `finpilot-troubleshooting.md`             |
-| Follow a worked example                        | `finpilot-examples.md`                    |
-| Initialize/ rename this template               | `finpilot-templates.md`                   |
-| Orient to repo architecture                    | `finpilot-overview.md`                    |
+Task-specific instructions are Agent Skills under
+`.agents/skills/<skill-name>/SKILL.md`. Agents discover them automatically from
+their descriptions. Use the matching skill before changing behavior; for an
+unfamiliar multi-phase task, start with `finpilot-overview`, continue with the
+domain skill, and finish with `finpilot-pr-checklist`. Not sure which skill
+fits? Load `finpilot-router` — it owns the routing table. The skill index with
+links lives in `.agents/skills/README.md`.
 
 ## Branch Strategy
 
@@ -135,6 +115,6 @@ Assisted-by: [Model Name] via [Tool Name]
 
 ---
 
-**Last Updated**: 2026-08-04
+**Last Updated**: 2026-08-06
 **Template Version**: finpilot (Agent UX Overhaul)
 **Maintainer**: Universal Blue Community

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,66 @@
 
 ## Start here
 
-Task-specific instructions are Agent Skills under
-`.agents/skills/<skill-name>/SKILL.md`. Agents discover them automatically from
-their descriptions. Use the matching skill before changing behavior; for an
-unfamiliar multi-phase task, start with `finpilot-overview`, continue with the
-domain skill, and finish with `finpilot-pr-checklist`. Not sure which skill
-fits? Load `finpilot-router` — it owns the routing table. The skill index with
-links lives in `.agents/skills/README.md`.
+Read the repo skill docs before changing behavior:
+
+- `.agents/skills/finpilot-overview.md` — architecture, repo layout, task router
+- `.agents/skills/finpilot-onboarding.md` — fork bootstrap: rename, Actions, token, first build
+- `.agents/skills/finpilot-packages.md` — decision tree (dnf5 vs Brew vs Flatpak)
+- `.agents/skills/finpilot-custom.md` — Brewfiles, Flatpaks, ujust rules
+- `.agents/skills/finpilot-build.md` — Containerfile, Justfile, build scripts
+- `.agents/skills/finpilot-ci.md` — GitHub Actions workflows, composite actions, Renovate
+- `.agents/skills/finpilot-maintain.md` — ongoing: Renovate PRs, signing, local test loop
+- `.agents/skills/finpilot-troubleshooting.md` — symptom → cause → fix
+- `.agents/skills/finpilot-pr-checklist.md` — PR gates by change type
+- `.agents/skills/finpilot-examples.md` — runnable examples and activation patterns
+
+### Task Router
+
+| I need to…                                     | Load                                      |
+| ---------------------------------------------- | ----------------------------------------- |
+| Bootstrap a new fork                           | `finpilot-onboarding.md`                  |
+| Add/remove a package                           | `finpilot-packages.md`                    |
+| Change Brewfiles, Flatpaks, or ujust           | `finpilot-custom.md`                      |
+| Change Containerfile, Justfile, or build/\*.sh | `finpilot-build.md`                       |
+| Fix CI or Renovate                             | `finpilot-ci.md` / `finpilot-maintain.md` |
+| Open a PR                                      | `finpilot-pr-checklist.md`                |
+| Debug a build or deploy failure                | `finpilot-troubleshooting.md`             |
+| Follow a worked example                        | `finpilot-examples.md`                    |
+| Initialize/ rename this template               | `finpilot-templates.md`                   |
+| Orient to repo architecture                    | `finpilot-overview.md`                    |
+
+## Branch Strategy
+
+- `main` is the testing branch and publishes `:stable-testing`.
+- `stable` is the production branch and publishes `:stable`.
+- All feature and Renovate pull requests target `main`.
+- pull[bot] opens promotion pull requests from `main` to `stable` using `.github/pull.yml`.
+- Never make independent changes on `stable`; approve promotion only after testing the candidate image.
+
+## CI Structure
+
+```text
+.github/
+├── pull.yml                  # pull[bot] main -> stable promotion
+└── workflows/
+    ├── build-image.yml       # PR builds and branch-aware image publishing
+    ├── pr-validation.yml     # Required validation for PRs to main
+    ├── renovate.yml          # Dependency update automation
+    └── validate-*.yml        # Targeted file validation
+```
+
+## Release Workflow
+
+1. Open changes against `main`.
+2. Merge only after required validation and image build checks pass.
+3. Test `ghcr.io/OWNER/IMAGE:stable-testing`.
+4. Review the pull[bot] promotion PR from `main` to `stable`.
+5. Merge the promotion to publish `ghcr.io/OWNER/IMAGE:stable`.
+
+| Branch | Mutable image tag | Audience |
+| --- | --- | --- |
+| `main` | `:stable-testing` | Testers and release candidates |
+| `stable` | `:stable` | Production systems |
 
 ## CRITICAL: GitHub API Usage
 
@@ -60,11 +113,13 @@ links lives in `.agents/skills/README.md`.
 5. **ALWAYS** use `-y` flag for non-interactive installs
 6. **NEVER** use `dnf5` in ujust files — only Brewfile/Flatpak shortcuts
 7. **NEVER** push directly to `main` (only via PR with passing `validate` check)
-8. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
-9. **ALWAYS** run shellcheck/YAML validation before committing
-10. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`
-11. **ALWAYS** validate that new Flatpak IDs exist on Flathub before adding
-12. **NEVER** modify validation workflows without understanding impact on PR checks
+8. **NEVER** push directly to `stable`; promote tested `main` commits through pull[bot]
+9. **ALWAYS** target `main` and test `:stable-testing` before approving promotion
+10. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
+11. **ALWAYS** run shellcheck/YAML validation before committing
+12. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`
+13. **ALWAYS** validate that new Flatpak IDs exist on Flathub before adding
+14. **NEVER** modify validation workflows without understanding impact on PR checks
 
 ## Analysis vs Implementation
 
@@ -80,6 +135,6 @@ Assisted-by: [Model Name] via [Tool Name]
 
 ---
 
-**Last Updated**: 2026-08-05
+**Last Updated**: 2026-08-04
 **Template Version**: finpilot (Agent UX Overhaul)
 **Maintainer**: Universal Blue Community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@
 
 Thanks for helping out!
 
-Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
+Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for general contribution information.
 
-This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+This repository builds custom images. Changes to shared Bluefin behavior usually belong in [@projectbluefin/common](https://github.com/projectbluefin/common); see the [architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture) before opening a pull request.
+
+## Agent-Driven Development Workflow
+
+1. Create a focused feature branch from `main`.
+2. Use Conventional Commits for every commit.
+3. Open a pull request targeting `main`, never `stable`.
+4. Merge after all required validation and build checks pass.
+5. Verify the new `:stable-testing` image from `main`.
+6. Wait for pull[bot] to open a promotion pull request to `stable`.
+7. Review and approve the promotion after testing.
+8. Merge the promotion to publish the production `:stable` image.
+
+AI agents must always target `main`, follow repository validation instructions, and leave production promotion to a human reviewer. Human maintainers should review feature pull requests, test `:stable-testing`, and approve pull[bot] promotion pull requests only when the candidate is ready for production.

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 export IMAGE_NAME := env("IMAGE_NAME", "finpilot")
-export DEFAULT_TAG := env("DEFAULT_TAG", "stable")
+export DEFAULT_TAG := env("DEFAULT_TAG", "stable") # CI overrides to "stable-testing" on main
 export PODMAN := env("PODMAN", "podman")
 export REPO_ORG := env("GITHUB_REPOSITORY_OWNER", "projectbluefin")
 export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest@sha256:2b52843ea2bfda73b0a08d97e76b734393b1d3a804681b9fabb26723bd3a2f0b")

--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ This template works best with **phased prompts** that let Copilot bootstrap your
 Use this prompt first to get your fork building:
 
 ```
-Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repository. Use the `finpilot-onboarding` skill first, then:
+Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repository. Read `.agents/skills/finpilot-onboarding.md` first, then:
 1. Rename `finpilot` in the 7 required files
 2. Enable GitHub Actions and set RENOVATE_TOKEN (repo + workflow scopes)
-3. Configure branch protection for `main` with `validate` as a required status check
-4. Enable auto-merge
-5. Trigger the first green build on `main`
-6. Add the "What Makes this Raptor Different" section to README.md (with placeholders)
+3. Create `stable` from `main`
+4. Replace OWNER in `.github/pull.yml` and install the pull GitHub App
+5. Protect `main` and `stable`, with `validate` required on `main`
+6. Enable auto-merge
+7. Trigger the first green build on `main`
+8. Add the "What Makes this Raptor Different" section to README.md (with placeholders)
 ```
 
 ### Phase 2 — Customize
@@ -60,7 +62,7 @@ Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repo
 Once the first build is green, use this prompt to add packages:
 
 ```
-Use the `finpilot-packages` and `finpilot-custom` skills, then:
+Read `.agents/skills/finpilot-packages.md` and `.agents/skills/finpilot-custom.md`, then:
 1. Add one system package to the image in `build/10-build.sh`
 2. Add one CLI tool to `custom/brew/default.Brewfile`
 3. Add one GUI app to `custom/flatpaks/default.preinstall`
@@ -68,6 +70,7 @@ Use the `finpilot-packages` and `finpilot-custom` skills, then:
 5. Update the README "What Makes this Raptor Different" section with the new entries
 6. Run `just build && just build-qcow2 && just run-vm-qcow2` to verify locally
 7. Open a PR and merge once `validate` passes
+8. Test the `:stable-testing` image, then approve the pull[bot] promotion PR
 ```
 
 ### Phase 3 — Production
@@ -75,10 +78,10 @@ Use the `finpilot-packages` and `finpilot-custom` skills, then:
 When you are ready for production, use this prompt to harden the setup:
 
 ```
-Use the `finpilot-maintain` and `finpilot-ci` skills, then:
+Read `.agents/skills/finpilot-maintain.md` and `.agents/skills/finpilot-ci.md`, then:
 1. Enable keyless image signing by uncommenting the step in `.github/workflows/build-image.yml`
 2. Verify the cosign command works: cosign verify --certificate-identity-regexp="https://github.com/USER/REPO/.github/workflows/" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" ghcr.io/USER/REPO:stable
-3. Follow the maintenance schedule in the `finpilot-maintain` skill
+3. Review the maintenance schedule in `finpilot-maintain.md`
 ```
 
 ## What's Included
@@ -88,9 +91,11 @@ Use the `finpilot-maintain` and `finpilot-ci` skills, then:
 - Automated builds via GitHub Actions on every commit
 - Self-hosted Renovate for automated dependency updates
 - Automatic cleanup of old images (90+ days) to keep it tidy
-- Pull request workflow - test changes before merging to main
-  - PRs build and validate before merge
-  - `main` branch builds `:stable` images
+- Two-branch delivery with pull[bot] promotion
+  - Pull requests target `main` and build before merge
+  - `main` publishes candidate images as `:stable-testing`
+  - pull[bot] opens promotion PRs from `main` to `stable`
+  - `stable` publishes production images as `:stable`
 - Validates your files on pull requests so you never break a build:
   - Brewfile, Justfile, ShellCheck, Renovate config, and it'll even check to make sure the flatpak you add exists on FlatHub
 - Production Grade Features
@@ -146,11 +151,26 @@ Important: Change `finpilot` to your repository name in these 7 files:
 - Go to the "Actions" tab in your repository
 - Click "I understand my workflows, go ahead and enable them"
 
-Your first build will start automatically!
+Your first testing build will start automatically and publish `:stable-testing`.
 
 Note: Image signing is disabled by default. Your images will build successfully without any signing keys. Once you're ready for production, see "Optional: Enable Image Signing" below.
 
-### 4. Enable Renovate (Required)
+### 4. Configure Testing and Stable Branches
+
+Create the production branch from `main`:
+
+```bash
+git switch main
+git switch -c stable
+git push --set-upstream origin stable
+git switch main
+```
+
+Replace both `OWNER` placeholders in `.github/pull.yml` with your GitHub username, then install the [pull GitHub App](https://github.com/apps/pull) for your repository. pull[bot] will open promotion PRs from `main` to `stable`; do not make independent changes on `stable`.
+
+See the [setup checklist](.github/SETUP_CHECKLIST.md) for configuration validation and branch protection details.
+
+### 5. Enable Renovate (Required)
 
 Renovate automatically updates dependencies and GitHub Actions (including workflow files). This template uses a self-hosted Renovate runner via `projectbluefin/actions`.
 
@@ -174,7 +194,7 @@ Renovate automatically updates dependencies and GitHub Actions (including workfl
 
 Renovate will run every 6 hours and on config changes. It pins GitHub Actions to SHAs and updates tracked image digests automatically.
 
-### 5. Customize Your Image
+### 6. Customize Your Image
 
 Choose your base image in `Containerfile` (the `FROM` line):
 
@@ -197,21 +217,40 @@ Customize your apps:
 - Add Flatpaks in `custom/flatpaks/` ([guide](custom/flatpaks/README.md))
 - Add ujust commands in `custom/ujust/` ([guide](custom/ujust/README.md))
 
-### 6. Development Workflow
+### 7. Development Workflow
 
-All changes should be made via pull requests:
+| Branch | Image tag | Purpose |
+| --- | --- | --- |
+| `main` | `:stable-testing` | Integration and user testing |
+| `stable` | `:stable` | Approved production releases |
 
-1. Open a pull request on GitHub with the change you want.
-2. The PR will automatically trigger:
-   - Build validation
-   - Brewfile, Flatpak, Justfile, and shellcheck validation
-   - Test image build
-3. Once checks pass, merge the PR
-4. Merging triggers publishes a `:stable` image
+All feature and Renovate pull requests target `main`:
 
-### 7. Deploy Your Image
+1. Create a feature branch and open a pull request to `main`.
+2. Wait for build, Brewfile, Flatpak, Justfile, and shell validation.
+3. Merge the pull request to publish `:stable-testing`.
+4. Test the candidate image:
 
-Switch to your image:
+   ```bash
+   sudo bootc switch ghcr.io/your-username/your-repo-name:stable-testing
+   sudo systemctl reboot
+   ```
+
+5. Review the promotion PR that pull[bot] opens from `main` to `stable`.
+6. Approve and merge it to publish `:stable`.
+
+Never push directly to `stable`; its history is managed with pull[bot]'s `hardreset` promotion strategy.
+
+### 8. Deploy Your Image
+
+To test the current candidate:
+
+```bash
+sudo bootc switch ghcr.io/your-username/your-repo-name:stable-testing
+sudo systemctl reboot
+```
+
+To deploy the promoted production image:
 
 ```bash
 sudo bootc switch ghcr.io/your-username/your-repo-name:stable
@@ -255,6 +294,12 @@ Ready to take your custom OS to production? Enable these features for enhanced s
 
 ### Production Checklist
 
+- [ ] **Configure Testing-to-Stable Promotion**
+  - Create `stable` from `main`
+  - Replace `OWNER` in `.github/pull.yml`
+  - Install the [pull GitHub App](https://github.com/apps/pull)
+  - Protect `stable` from direct pushes
+
 - [ ] **Enable Image Signing** (Recommended)
   - Provides cryptographic verification of your images
   - Prevents tampering and ensures authenticity
@@ -264,41 +309,35 @@ Ready to take your custom OS to production? Enable these features for enhanced s
 
 - [ ] **Enable Image Rechunking** (Recommended)
   - Optimizes bootc image layers for better update performance
-  - Reduces update sizes by 5-10x when combined with package cadence data
   - Improves download resumability with evenly sized layers
-  - To enable:
-    1. Edit `.github/workflows/build-image.yml`
-    2. Find the "OPTIONAL: Rechunking" section
-    3. Uncomment the `bootc-build/chunka` step
-  - For optimal results, also add `bootc-build/apply-pkg-intervals` and a `pkg-cadence.yml` workflow
+  - Set `ENABLE_RECHUNKING: "true"` in `.github/workflows/build-image.yml`
+  - Uses OCI-native chunkah; `/usr/libexec/bootc-base-imagectl` is not required
   - Status: **Not enabled by default** (optional optimization)
 
 #### Adding Image Rechunking
 
-After building your bootc image, add a rechunk step before pushing to the registry. The template ships with a commented `bootc-build/chunka` step in `.github/workflows/build-image.yml`:
+The old rechunking recipe used `/usr/libexec/bootc-base-imagectl`, which is absent from many Universal Blue images. Do not copy that recipe or install a legacy rechunker: its layer format is not a safe migration path to the current implementation.
+
+Finpilot instead uses the OCI-native [`bootc-build/chunka`](https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka) action. The action runs chunkah from a pinned container and replaces the locally built image before the existing tag and push steps. The default Fedora Silverblue-based finpilot image is RPM-based, so chunkah can discover components from its RPM database without `bootc-base-imagectl`.
+
+To enable it, change the workflow environment value:
 
 ```yaml
-- name: Rechunk image
-  if: github.event_name != 'pull_request'
-  id: rechunk-image
-  uses: projectbluefin/actions/bootc-build/chunka@6231015b336556d2ff0adc1d1e59514bf19dcb42 # v1
-  with:
-    source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
-    max-layers: 128
+env:
+  ENABLE_RECHUNKING: "true"
+  RECHUNK_MAX_LAYERS: "128"
 ```
 
-This uses [chunkah](https://github.com/coreos/chunkah) to reorganize OCI layers without rpm-ostree. Renovate will keep the action updated once it is uncommented.
+Rechunking runs only for publish builds, not pull requests. It requires additional runner time and temporary storage. Keep `ENABLE_RECHUNKING` set to `"false"` if those costs are more important than smaller OTA deltas.
 
-**Parameters:**
+**Custom base images:** This switch is supported for the template's default RPM-based image. BuildStream-produced images strip the component xattrs chunkah needs and require an `xattr-manifest`; changing to one of those images is not a one-line setup. See the action's `xattr-manifest` input before replacing the default base.
 
-- `max-layers`: Maximum number of layers for the rechunked image (128 is a typical bootc default)
-- `source-image`: Local image reference to rechunk
-
-**For optimal OTA deltas**, also add `bootc-build/apply-pkg-intervals` before the rechunk step and create a `.github/workflows/pkg-cadence.yml` workflow that calls `projectbluefin/actions/.github/workflows/reusable-pkg-cadence.yml@v1`. This groups packages by update cadence (weekly, monthly, quarterly, yearly) so a typical update only downloads layers that actually changed. Without it, chunkah still works but uses default layer grouping.
+**Optional package cadence:** Basic rechunking does not require package cadence data. Advanced deployments can run [`bootc-build/apply-pkg-intervals`](https://github.com/projectbluefin/actions/tree/main/bootc-build/apply-pkg-intervals) before rechunking and maintain `files/pkg-intervals.tsv` with the reusable package-cadence workflow. That workflow requires a repository GitHub App ID and private key, so configure it separately rather than treating it as part of basic enablement.
 
 **References:**
 
-- [CoreOS rpm-ostree build-chunked-oci documentation](https://coreos.github.io/rpm-ostree/build-chunked-oci/)
+- [chunkah](https://github.com/coreos/chunkah)
+- [projectbluefin/actions rechunking](https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka)
 - [bootc documentation](https://containers.github.io/bootc/)
 
 ### After Enabling Production Features
@@ -307,6 +346,15 @@ Your workflow will:
 
 - Sign all images using keyless OIDC signing
 - Provide cryptographic proof of authenticity via SLSA build provenance attestation
+
+Users can verify your images with:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/your-username/your-repo-name/.github/workflows/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  ghcr.io/your-username/your-repo-name:stable
+```
 
 ## Detailed Guides
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This template works best with **phased prompts** that let Copilot bootstrap your
 Use this prompt first to get your fork building:
 
 ```
-Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repository. Read `.agents/skills/finpilot-onboarding.md` first, then:
+Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repository. Read `finpilot-onboarding` first, then:
 1. Rename `finpilot` in the 7 required files
 2. Enable GitHub Actions and set RENOVATE_TOKEN (repo + workflow scopes)
 3. Create `stable` from `main`
@@ -62,7 +62,7 @@ Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repo
 Once the first build is green, use this prompt to add packages:
 
 ```
-Read `.agents/skills/finpilot-packages.md` and `.agents/skills/finpilot-custom.md`, then:
+Read `finpilot-packages` and `finpilot-custom`, then:
 1. Add one system package to the image in `build/10-build.sh`
 2. Add one CLI tool to `custom/brew/default.Brewfile`
 3. Add one GUI app to `custom/flatpaks/default.preinstall`
@@ -78,10 +78,10 @@ Read `.agents/skills/finpilot-packages.md` and `.agents/skills/finpilot-custom.m
 When you are ready for production, use this prompt to harden the setup:
 
 ```
-Read `.agents/skills/finpilot-maintain.md` and `.agents/skills/finpilot-ci.md`, then:
+Read `finpilot-maintain` and `finpilot-ci`, then:
 1. Enable keyless image signing by uncommenting the step in `.github/workflows/build-image.yml`
 2. Verify the cosign command works: cosign verify --certificate-identity-regexp="https://github.com/USER/REPO/.github/workflows/" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" ghcr.io/USER/REPO:stable
-3. Review the maintenance schedule in `finpilot-maintain.md`
+3. Review the maintenance schedule in `finpilot-maintain`
 ```
 
 ## What's Included
@@ -309,35 +309,41 @@ Ready to take your custom OS to production? Enable these features for enhanced s
 
 - [ ] **Enable Image Rechunking** (Recommended)
   - Optimizes bootc image layers for better update performance
+  - Reduces update sizes by 5-10x when combined with package cadence data
   - Improves download resumability with evenly sized layers
-  - Set `ENABLE_RECHUNKING: "true"` in `.github/workflows/build-image.yml`
-  - Uses OCI-native chunkah; `/usr/libexec/bootc-base-imagectl` is not required
+  - To enable:
+    1. Edit `.github/workflows/build-image.yml`
+    2. Find the "OPTIONAL: Rechunking" section
+    3. Uncomment the `bootc-build/chunka` step
+  - For optimal results, also add `bootc-build/apply-pkg-intervals` and a `pkg-cadence.yml` workflow
   - Status: **Not enabled by default** (optional optimization)
 
 #### Adding Image Rechunking
 
-The old rechunking recipe used `/usr/libexec/bootc-base-imagectl`, which is absent from many Universal Blue images. Do not copy that recipe or install a legacy rechunker: its layer format is not a safe migration path to the current implementation.
-
-Finpilot instead uses the OCI-native [`bootc-build/chunka`](https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka) action. The action runs chunkah from a pinned container and replaces the locally built image before the existing tag and push steps. The default Fedora Silverblue-based finpilot image is RPM-based, so chunkah can discover components from its RPM database without `bootc-base-imagectl`.
-
-To enable it, change the workflow environment value:
+After building your bootc image, add a rechunk step before pushing to the registry. The template ships with a commented `bootc-build/chunka` step in `.github/workflows/build-image.yml`:
 
 ```yaml
-env:
-  ENABLE_RECHUNKING: "true"
-  RECHUNK_MAX_LAYERS: "128"
+- name: Rechunk image
+  if: github.event_name != 'pull_request'
+  id: rechunk-image
+  uses: projectbluefin/actions/bootc-build/chunka@6231015b336556d2ff0adc1d1e59514bf19dcb42 # v1
+  with:
+    source-image: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
+    max-layers: 128
 ```
 
-Rechunking runs only for publish builds, not pull requests. It requires additional runner time and temporary storage. Keep `ENABLE_RECHUNKING` set to `"false"` if those costs are more important than smaller OTA deltas.
+This uses [chunkah](https://github.com/coreos/chunkah) to reorganize OCI layers without rpm-ostree. Renovate will keep the action updated once it is uncommented.
 
-**Custom base images:** This switch is supported for the template's default RPM-based image. BuildStream-produced images strip the component xattrs chunkah needs and require an `xattr-manifest`; changing to one of those images is not a one-line setup. See the action's `xattr-manifest` input before replacing the default base.
+**Parameters:**
 
-**Optional package cadence:** Basic rechunking does not require package cadence data. Advanced deployments can run [`bootc-build/apply-pkg-intervals`](https://github.com/projectbluefin/actions/tree/main/bootc-build/apply-pkg-intervals) before rechunking and maintain `files/pkg-intervals.tsv` with the reusable package-cadence workflow. That workflow requires a repository GitHub App ID and private key, so configure it separately rather than treating it as part of basic enablement.
+- `max-layers`: Maximum number of layers for the rechunked image (128 is a typical bootc default)
+- `source-image`: Local image reference to rechunk
+
+**For optimal OTA deltas**, also add `bootc-build/apply-pkg-intervals` before the rechunk step and create a `.github/workflows/pkg-cadence.yml` workflow that calls `projectbluefin/actions/.github/workflows/reusable-pkg-cadence.yml@v1`. This groups packages by update cadence (weekly, monthly, quarterly, yearly) so a typical update only downloads layers that actually changed. Without it, chunkah still works but uses default layer grouping.
 
 **References:**
 
-- [chunkah](https://github.com/coreos/chunkah)
-- [projectbluefin/actions rechunking](https://github.com/projectbluefin/actions/tree/main/bootc-build/chunka)
+- [CoreOS rpm-ostree build-chunked-oci documentation](https://coreos.github.io/rpm-ostree/build-chunked-oci/)
 - [bootc documentation](https://containers.github.io/bootc/)
 
 ### After Enabling Production Features


### PR DESCRIPTION
## Summary
- add `.github/pull.yml` for hard-reset promotion from `main` to `stable`
- publish `:stable-testing` from `main` and `:stable` from `stable`
- add setup, contributor, agent, and CI documentation for the two-branch workflow

## Validation
- `just --list`
- `just check`
- `bash -n build/*.sh`
- branch/tag workflow invariant checks
- `git diff --check`

Not run because the tools are unavailable in this environment:
- YAML parsing with PyYAML (`python3` has no `yaml` module)
- `actionlint`
- `shellcheck`
- container/image build

## Consumer setup
Template users must create `stable`, replace `OWNER` in `.github/pull.yml`, install the Pull GitHub App, and protect both branches as documented.

Closes #57

Assisted-by: GPT-5.6 Sol via GitHub Copilot CLI
