### PR TITLE
ci: add two-branch testing/stable workflow with pull[bot] promotion

### DIFF
--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -45,7 +45,36 @@ git push origin main
 
 **Agent skills:** `finpilot-onboarding` (branch protection), `finpilot-ci` (Renovate config)
 
-### 5. Add "What Makes this Raptor Different" to README
+### 5. Create Stable Branch
+
+- [ ] Create the `stable` branch from `main`:
+
+```bash
+git checkout main
+git checkout -b stable
+git push origin stable
+git checkout main
+```
+
+### 6. Install pull[bot] GitHub App (Required for Promotion)
+
+The [pull](https://github.com/apps/pull) GitHub App automatically promotes tested changes from `main` → `stable`.
+
+- [ ] Install the pull App: **Settings → Applications → Search "pull" → Install**
+- [ ] Replace `OWNER` placeholder in `.github/pull.yml` with your GitHub username:
+  ```bash
+  sed -i "s/OWNER/your-github-username/g" .github/pull.yml
+  ```
+- [ ] Commit and push:
+  ```bash
+  git add .github/pull.yml
+  git commit -m "chore: configure pull[bot] for OWNER"
+  git push origin main
+  ```
+
+**Workflow:** `main` (PRs land → `:stable-testing` image) → pull[bot] auto-creates PR → `stable` (approved → `:stable` production image)
+
+### 7. Add "What Makes this Raptor Different" to README
 
 - [ ] Open `README.md`
 - [ ] Paste the raptor section template (see README or use the `finpilot-onboarding` skill)
@@ -54,9 +83,14 @@ git push origin main
 
 **Agent skills:** `finpilot-onboarding` (raptor section), `finpilot-maintain` (maintenance requirement)
 
-### 6. Deploy
+### 8. Deploy
 
 ```bash
+# Deploy testing image (from main branch)
+sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable-testing
+sudo systemctl reboot
+
+# Deploy production image (from stable branch, after pull[bot] promotion)
 sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable
 sudo systemctl reboot
 ```
@@ -83,7 +117,9 @@ Which skill to load for each checklist block above:
 | Rename (step 1)                       | `finpilot-templates`, `finpilot-onboarding`     |
 | Enable Actions (step 2)               | `finpilot-onboarding`                           |
 | Renovate + branch protection (step 4) | `finpilot-onboarding`, `finpilot-ci`            |
-| Raptor section (step 5)               | `finpilot-onboarding`, `finpilot-maintain`      |
+| Stable branch (step 5)                | `finpilot-onboarding`                           |
+| pull[bot] install (step 6)            | `finpilot-ci`                                   |
+| Raptor section (step 7)               | `finpilot-onboarding`, `finpilot-maintain`      |
 | Signing (optional)                    | `finpilot-templates`                            |
 
 **Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required by the `finpilot-maintain` skill.

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,12 @@
+version: "1"
+rules:
+  - base: stable
+    upstream: main
+    mergeMethod: hardreset
+    mergeUnstable: false
+    reviewers:
+      - OWNER
+    conflictReviewers:
+      - OWNER
+label: "promotion"
+conflictLabel: "promotion-conflict"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -12,11 +12,21 @@ on:
   push:
     branches:
       - main
+      - stable
     paths-ignore:
       - "**.md"
       - ".github/workflows/*validate*.yml"
-  schedule:
-    - cron: "05 10 * * *" # 10:05am UTC everyday
+  pull_request:
+    branches:
+      - main
+      - stable
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*validate*.yml"
+  merge_group:
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*validate*.yml"
   workflow_dispatch:
 
 permissions:
@@ -33,6 +43,8 @@ env:
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
   DEFAULT_TAG: "stable"
+  PRODUCTION_BRANCH: stable
+  TESTING_BRANCH: main
   REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
 
 concurrency:
@@ -55,6 +67,20 @@ jobs:
         run: |
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
           echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
+      - name: Determine image tag
+        id: determine-tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # If not on the production branch, this is a testing build
+          if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]; then
+            echo "DEFAULT_TAG=${DEFAULT_TAG}-testing" >> ${GITHUB_ENV}
+            echo "Building testing image: ${DEFAULT_TAG}-testing"
+          else
+            echo "Building production image: ${DEFAULT_TAG}"
+          fi
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -172,7 +198,7 @@ jobs:
                           "${ALIAS_TAGS}"
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
@@ -180,7 +206,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GHCR
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         id: push
         uses: projectbluefin/actions/bootc-build/push-image@c3ffb5dd594f4a363298bacc7ad4cfe18457fa97 # v1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,12 +59,23 @@ links lives in `.agents/skills/README.md`.
 4. **ALWAYS** use `dnf5` exclusively (never `dnf`, `yum`, `rpm-ostree`)
 5. **ALWAYS** use `-y` flag for non-interactive installs
 6. **NEVER** use `dnf5` in ujust files — only Brewfile/Flatpak shortcuts
-7. **NEVER** push directly to `main` (only via PR with passing `validate` check)
+7. **NEVER** push directly to `main` (only via PR with passing `validate` check); use pull[bot] to promote tested changes from `main` → `stable`
 8. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
 9. **ALWAYS** run shellcheck/YAML validation before committing
 10. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`
 11. **ALWAYS** validate that new Flatpak IDs exist on Flathub before adding
 12. **NEVER** modify validation workflows without understanding impact on PR checks
+
+## Branch Strategy
+
+| Branch | Purpose | Image Tag | Trigger |
+|--------|---------|-----------|--------|
+| `main` | Testing — PRs land here, CI validates changes | `:stable-testing` | Push to `main`, PRs to `main` |
+| `stable` | Production — promoted via pull[bot] | `:stable` | Push to `stable` (via pull[bot]) |
+
+**Promotion flow:** PR merges to `main` → `:stable-testing` image built → pull[bot] auto-creates PR `main` → `stable` → approved → `:stable` production image built.
+
+**pull[bot] configuration:** See `.github/pull.yml`. Replace `OWNER` placeholder with your GitHub username after installing the [pull](https://github.com/apps/pull) GitHub App.
 
 ## Analysis vs Implementation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,31 @@ Thanks for helping out!
 Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
 
 This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+
+## Agent-Driven Development Workflow
+
+This repository uses a two-branch testing/stable workflow with automatic promotion via [pull[bot]](https://github.com/apps/pull).
+
+### The Workflow
+
+1. **Create a feature branch** from `main` and open a PR targeting `main`
+2. **PR triggers CI**: build validation, Brewfile/Flatpak/Justfile/shellcheck checks
+3. **Merge the PR** once all checks pass
+4. **Testing image builds**: `main` push triggers `:stable-testing` image
+5. **pull[bot] promotes**: Auto-creates a PR from `main` → `stable`
+6. **Review the promotion PR**: Verify changes look good
+7. **Approve and merge**: Triggers `:stable` production image build
+
+### For AI Agents
+
+- **Always target `main`** for feature branches and PRs
+- **Use conventional commits** for all commits (see `.github/commit-convention.md`)
+- **Never push directly to `stable`** — use pull[bot] for promotion
+- **Run pre-commit checks** before committing (shellcheck, YAML validation, Justfile syntax)
+
+### For Humans
+
+- **Review PRs** targeting `main` for correctness
+- **Test images** using `:stable-testing` tag before approving promotion
+- **Review and approve** pull[bot] promotion PRs to `stable`
+- **Replace `OWNER`** in `.github/pull.yml` with your GitHub username after installing the pull App

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 export IMAGE_NAME := env("IMAGE_NAME", "finpilot")
-export DEFAULT_TAG := env("DEFAULT_TAG", "stable")
+export DEFAULT_TAG := env("DEFAULT_TAG", "stable")  # CI overrides to "stable-testing" on main branch
 export PODMAN := env("PODMAN", "podman")
 export REPO_ORG := env("GITHUB_REPOSITORY_OWNER", "projectbluefin")
 export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest@sha256:2b52843ea2bfda73b0a08d97e76b734393b1d3a804681b9fabb26723bd3a2f0b")

--- a/README.md
+++ b/README.md
@@ -88,9 +88,12 @@ Use the `finpilot-maintain` and `finpilot-ci` skills, then:
 - Automated builds via GitHub Actions on every commit
 - Self-hosted Renovate for automated dependency updates
 - Automatic cleanup of old images (90+ days) to keep it tidy
+- **Two-branch workflow**: `main` builds `:stable-testing`, pull[bot] promotes to `stable` which builds `:stable`
+- **pull[bot] promotion**: Automatically creates PRs from `main` → `stable` using hardreset; skip if CI is failing
 - Pull request workflow - test changes before merging to main
   - PRs build and validate before merge
-  - `main` branch builds `:stable` images
+  - `main` branch builds `:stable-testing` images
+  - `stable` branch builds `:stable` production images
 - Validates your files on pull requests so you never break a build:
   - Brewfile, Justfile, ShellCheck, Renovate config, and it'll even check to make sure the flatpak you add exists on FlatHub
 - Production Grade Features
@@ -199,22 +202,50 @@ Customize your apps:
 
 ### 6. Development Workflow
 
-All changes should be made via pull requests:
+All changes should be made via pull requests targeting `main`:
 
-1. Open a pull request on GitHub with the change you want.
-2. The PR will automatically trigger:
-   - Build validation
-   - Brewfile, Flatpak, Justfile, and shellcheck validation
-   - Test image build
+| Branch | Purpose | Image Tag |
+|--------|---------|----------|
+| `main` | Testing — PRs land here | `:stable-testing` |
+| `stable` | Production — promoted via pull[bot] | `:stable` |
+
+**Step-by-step workflow:**
+
+1. Create a feature branch and open a PR targeting `main`
+2. PR triggers build validation, Brewfile/Flatpak/Justfile/shellcheck checks
 3. Once checks pass, merge the PR
-4. Merging triggers publishes a `:stable` image
+4. Merging triggers a `:stable-testing` image build on `main`
+5. When you're ready for production, pull[bot] auto-creates a PR from `main` → `stable`
+6. Review and approve the promotion PR
+7. Approved promotion triggers a `:stable` production image build on `stable`
+
+**Testing your image before promotion:**
+
+```bash
+# Test the latest :stable-testing image
+sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable-testing
+sudo systemctl reboot
+```
+
+**After promotion to stable:**
+
+```bash
+# Deploy the production image
+sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable
+sudo systemctl reboot
+```
 
 ### 7. Deploy Your Image
 
 Switch to your image:
 
 ```bash
+# Production image (from stable branch)
 sudo bootc switch ghcr.io/your-username/your-repo-name:stable
+sudo systemctl reboot
+
+# Testing image (from main branch, before promotion)
+sudo bootc switch ghcr.io/your-username/your-repo-name:stable-testing
 sudo systemctl reboot
 ```
 


### PR DESCRIPTION
## Summary

Add a two-branch testing/stable workflow to finpilot, mirroring the pattern used by [bluefin-lts](https://github.com/ublue-os/bluefin-lts).

## Changes

### Task 1: Create `.github/pull.yml`
pull[bot] configuration for auto-promotion from `main` → `stable`.

### Task 2: Modify `.github/workflows/build-image.yml`
- Add `stable` branch to push and pull_request triggers
- Remove schedule cron
- Add `merge_group` support
- Add `PRODUCTION_BRANCH` and `TESTING_BRANCH` env vars
- Add "Determine image tag" step for testing builds
- Relax publish conditions

### Task 3: Update `.github/SETUP_CHECKLIST.md`
- Instructions to create `stable` branch
- Instructions to install pull GitHub App
- Deploy instructions for both `:stable-testing` and `:stable`

### Task 4: Update `README.md`
- Document dual-branch builds and pull[bot] promotion
- Add branch/tag/purpose table and workflow

### Task 5: Update `AGENTS.md`
- Add Branch Strategy section

### Task 6: Update `CONTRIBUTING.md`
- Add Agent-Driven Development Workflow section

### Task 7: Update `Justfile`
- Clarifying comment about CI tag override

### Task 8: Create `stable` branch
- `stable` is a copy of `main` (verified: no diff)