### PR TITLE
ci: add two-branch testing/stable workflow with pull[bot] promotion

### DIFF
--- a/.agents/skills/finpilot-ci/SKILL.md
+++ b/.agents/skills/finpilot-ci/SKILL.md
@@ -33,7 +33,7 @@ description: >-
 
 | File                     | Trigger                           | Purpose                                              |
 | ------------------------ | --------------------------------- | ---------------------------------------------------- |
-| `build-image.yml`        | push main, schedule, manual       | Build + push `:stable` via `projectbluefin/actions`  |
+| `build-image.yml`        | PR/push main + stable, merge group, manual | PR builds; publishes `:stable-testing` (main) or `:stable` (stable) |
 | `pr-validation.yml`      | PR → main                         | shellcheck + hadolint + pre-commit via `validate-pr` |
 | `renovate.yml`           | schedule 6h, push renovate config | Self-hosted Renovate runner                          |
 | `clean.yml`              | schedule weekly                   | Delete GHCR images older than 90 days                |
@@ -41,6 +41,14 @@ description: >-
 | `validate-flatpaks.yml`  | PR paths: `custom/flatpaks/**`    | Flathub app ID existence check                       |
 | `validate-justfiles.yml` | PR paths: `Justfile`              | `just --list` syntax check                           |
 | `validate-renovate.yml`  | PR paths: `.github/renovate.json` | `renovate-config-validator`                          |
+
+## Branch Promotion and Tags
+
+- `main` is the **testing branch** and publishes `:stable-testing`.
+- `stable` is the **production branch** and publishes `:stable`.
+- `.github/pull.yml` configures pull[bot] to promote `main` to `stable` (hardreset, blocked while CI fails).
+- The `Determine image tag` step sets `TAG_STREAM=testing` off the production branch; the `Finalize branch tags` step renames `testing*` tags to `stable-testing-*` so they can never collide with production `stable-daily*` aliases.
+- Never add branch-specific changes directly to `stable`; its history is hard-reset from `main` during promotion.
 
 ## Composite Action Pins
 

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -20,15 +20,53 @@
 - [ ] Settings → Actions → General → Enable workflows
 - [ ] Set "Read and write permissions"
 
-### 3. First Push
+### 3. Configure Testing and Production Branches
+
+This template uses a **two-branch model**: `main` publishes `:stable-testing`
+candidate images, and `stable` publishes `:stable` production images.
+pull[bot] promotes tested commits from `main` to `stable`.
+
+Create `stable` as an exact copy of `main`, then return to `main`:
 
 ```bash
-git add .
-git commit -m "feat: initial customization"
-git push origin main
+git switch main
+git switch -c stable
+git push --set-upstream origin stable
+git switch main
 ```
 
-### 4. Enable Renovate (Required)
+Then configure promotion:
+
+- [ ] Replace `OWNER` in `.github/pull.yml` (`reviewers` and `conflictReviewers`) with your GitHub username
+- [ ] Install the [pull GitHub App](https://github.com/apps/pull) for this repository
+- [ ] Validate the configuration at `https://pull.git.ci/check/YOUR_USERNAME/YOUR_REPO`
+- [ ] Never commit directly to `stable`; pull[bot] keeps it in sync with `main`
+
+The delivery flow is:
+
+```text
+feature branch
+      |
+      v
+PR -> main -> ghcr.io/OWNER/REPO:stable-testing
+             |
+             v
+       pull[bot] promotion PR
+             |
+             v
+          stable -> ghcr.io/OWNER/REPO:stable
+```
+
+### 4. First Change
+
+Open a pull request targeting `main`. After it merges:
+
+1. Verify the `:stable-testing` image.
+2. Wait for pull[bot] to open the `main` → `stable` promotion PR.
+3. Review and merge the promotion PR.
+4. Verify the `:stable` image.
+
+### 5. Enable Renovate (Required)
 
 - [ ] Create a **Classic PAT** (Settings → Developer settings → Personal access tokens → Tokens (classic))
   - Scopes: `repo` (full control) + `workflow` (update workflows)
@@ -41,11 +79,15 @@ git push origin main
   - Enable "Require status checks to pass before merging"
   - Add `validate` as a required status check
   - Enable "Require branches to be up to date before merging"
+- [ ] Configure branch protection for `stable`:
+  - Enable "Require a pull request before merging" and "Require status checks to pass before merging" so only pull[bot] promotion PRs land there
 - [ ] Renovate will create a PR to pin your GitHub Actions to SHAs
+
+Renovate targets `main`; approved changes reach `stable` through the same pull[bot] promotion flow.
 
 **Agent skills:** `finpilot-onboarding` (branch protection), `finpilot-ci` (Renovate config)
 
-### 5. Add "What Makes this Raptor Different" to README
+### 6. Add "What Makes this Raptor Different" to README
 
 - [ ] Open `README.md`
 - [ ] Paste the raptor section template (see README or use the `finpilot-onboarding` skill)
@@ -54,7 +96,16 @@ git push origin main
 
 **Agent skills:** `finpilot-onboarding` (raptor section), `finpilot-maintain` (maintenance requirement)
 
-### 6. Deploy
+### 7. Deploy
+
+Test the candidate image from `main`:
+
+```bash
+sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable-testing
+sudo systemctl reboot
+```
+
+After approving the promotion to `stable`, deploy the production image:
 
 ```bash
 sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable
@@ -82,8 +133,9 @@ Which skill to load for each checklist block above:
 | ------------------------------------- | ----------------------------------------------- |
 | Rename (step 1)                       | `finpilot-templates`, `finpilot-onboarding`     |
 | Enable Actions (step 2)               | `finpilot-onboarding`                           |
-| Renovate + branch protection (step 4) | `finpilot-onboarding`, `finpilot-ci`            |
-| Raptor section (step 5)               | `finpilot-onboarding`, `finpilot-maintain`      |
+| Branches and pull[bot] (step 3)       | `finpilot-onboarding`, `finpilot-ci`            |
+| Renovate + branch protection (step 5) | `finpilot-onboarding`, `finpilot-ci`            |
+| Raptor section (step 6)               | `finpilot-onboarding`, `finpilot-maintain`      |
 | Signing (optional)                    | `finpilot-templates`                            |
 
 **Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required by the `finpilot-maintain` skill.

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,22 @@
+# pull[bot] (https://github.com/apps/pull) promotes tested commits from the
+# testing branch (`main`) to the production branch (`stable`), mirroring the
+# ublue-os/bluefin-lts two-branch model.
+#
+# Template setup:
+#   1. Create the `stable` branch as a copy of `main`.
+#   2. Replace `OWNER` below with your GitHub username (reviewers and
+#      conflictReviewers).
+#   3. Install the pull GitHub App for your repository and validate the config
+#      at https://pull.git.ci/check/YOUR_USERNAME/YOUR_REPO
+version: "1"
+rules:
+  - base: stable
+    upstream: main
+    mergeMethod: hardreset
+    mergeUnstable: false
+    reviewers:
+      - OWNER
+    conflictReviewers:
+      - OWNER
+label: "promotion"
+conflictLabel: "promotion-conflict"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,22 +1,26 @@
 ---
 name: Build and Push Image
 
-# PR builds are disabled by default to save CI minutes. To enable them, add:
-#   pull_request:
-#     branches:
-#       - main
-#     paths-ignore:
-#       - "**.md"
-#       - ".github/workflows/*validate*.yml"
+# Two-branch model (mirrors ublue-os/bluefin-lts):
+#   main   = testing branch, publishes :stable-testing images
+#   stable = production branch, publishes :stable images
+# pull[bot] promotes tested commits from main to stable via .github/pull.yml.
 on:
-  push:
+  pull_request:
     branches:
       - main
+      - stable
     paths-ignore:
       - "**.md"
       - ".github/workflows/*validate*.yml"
-  schedule:
-    - cron: "05 10 * * *" # 10:05am UTC everyday
+  push:
+    branches:
+      - main
+      - stable
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*validate*.yml"
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -33,6 +37,8 @@ env:
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
   DEFAULT_TAG: "stable"
+  PRODUCTION_BRANCH: "stable"  # The branch that produces :stable production images
+  TESTING_BRANCH: "main"       # The branch where PRs land, produces :stable-testing images
   REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
 
 concurrency:
@@ -55,6 +61,25 @@ jobs:
         run: |
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
           echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
+      # Bluefin-lts pattern: anything not on the production branch is a testing build.
+      # We use a separate TAG_STREAM so generate-tags never sees a stream containing
+      # "stable" for testing builds (that would emit stable-daily* tags and collide
+      # with production); the Finalize branch tags step renames the tags instead.
+      - name: Determine image tag
+        id: determine-tag
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]]; then
+            echo "DEFAULT_TAG=${DEFAULT_TAG}-testing" >> "${GITHUB_ENV}"
+            echo "TAG_STREAM=testing" >> "${GITHUB_ENV}"
+            echo "Building testing image: ${DEFAULT_TAG}-testing"
+          else
+            echo "TAG_STREAM=stable" >> "${GITHUB_ENV}"
+            echo "Building production image: ${DEFAULT_TAG}"
+          fi
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -129,10 +154,43 @@ jobs:
         uses: projectbluefin/actions/bootc-build/generate-tags@c3ffb5dd594f4a363298bacc7ad4cfe18457fa97 # v1
         with:
           base-name: ${{ env.IMAGE_NAME }}
-          stream-name: ${{ env.DEFAULT_TAG }}
+          stream-name: ${{ env.TAG_STREAM }}
           version-label: ${{ steps.version.outputs.version }}
           event-name: ${{ github.event_name }}
           pr-number: ${{ github.event.number }}
+
+      # generate-tags emits stream-agnostic tags (testing / stable-daily + version
+      # aliases). This step renames testing tags to stable-testing-* and guarantees
+      # the mutable consumer tag (:stable / :stable-testing) is always published.
+      - name: Finalize branch tags
+        if: steps.detect-changes.outputs.should_build == 'true' || github.event_name != 'pull_request'
+        id: branch-tags
+        shell: bash
+        env:
+          GENERATED_TAGS: ${{ steps.generate-tags.outputs.tags }}
+        run: |
+          read -r -a generated_tags <<< "${GENERATED_TAGS}"
+          branch_tags=()
+
+          add_tag() {
+            local candidate="$1"
+            local existing
+            for existing in "${branch_tags[@]}"; do
+              [[ "${existing}" == "${candidate}" ]] && return
+            done
+            branch_tags+=("${candidate}")
+          }
+
+          for tag in "${generated_tags[@]}"; do
+            if [[ "${TAG_STREAM}" == "testing" ]]; then
+              tag="${tag/testing/stable-testing}"
+            fi
+            add_tag "${tag}"
+          done
+          add_tag "${DEFAULT_TAG}"
+
+          echo "tags=${branch_tags[*]}" >> "${GITHUB_OUTPUT}"
+          echo "default-tag=${DEFAULT_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Save DNF cache
         if: always() && !cancelled() && github.event_name != 'pull_request'
@@ -165,14 +223,16 @@ jobs:
         if: github.event_name != 'pull_request'
         shell: bash
         env:
-          ALIAS_TAGS: ${{ steps.generate-tags.outputs.tags }}
+          ALIAS_TAGS: ${{ steps.branch-tags.outputs.tags }}
         run: |
           sudo -E "$(command -v just)" tag-images "${IMAGE_NAME}" \
                           "${DEFAULT_TAG}" \
                           "${ALIAS_TAGS}"
 
+      # Publish from both the testing (main) and production (stable) branches;
+      # PR builds only build and validate, they never publish.
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
@@ -180,13 +240,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GHCR
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         id: push
         uses: projectbluefin/actions/bootc-build/push-image@c3ffb5dd594f4a363298bacc7ad4cfe18457fa97 # v1
         with:
           image-name: ${{ env.IMAGE_NAME }}
-          tags: ${{ steps.generate-tags.outputs.tags }}
-          default-tag: ${{ steps.generate-tags.outputs.default-tag }}
+          tags: ${{ steps.branch-tags.outputs.tags }}
+          default-tag: ${{ steps.branch-tags.outputs.default-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # OPTIONAL: Sign and attest (SLSA Build L2 provenance)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,46 @@ domain skill, and finish with `finpilot-pr-checklist`. Not sure which skill
 fits? Load `finpilot-router` — it owns the routing table. The skill index with
 links lives in `.agents/skills/README.md`.
 
+## Branch Strategy
+
+- `main` is the **testing branch** — all feature and Renovate PRs land here, and pushes publish `:stable-testing` images.
+- `stable` is the **production branch** — pushes publish `:stable` images.
+- pull[bot] promotes tested commits from `main` to `stable` using `.github/pull.yml` (hardreset merge, blocked while CI is failing).
+- Never make independent changes on `stable`; its history is hard-reset from `main` during promotion.
+
+## CI Structure
+
+```text
+.github/
+├── pull.yml                  # pull[bot] main -> stable promotion config
+└── workflows/
+    ├── build-image.yml       # PR builds + branch-aware publishing (:stable-testing / :stable)
+    ├── pr-validation.yml     # Required validation for PRs to main
+    ├── renovate.yml          # Dependency update automation
+    ├── clean.yml             # GHCR image cleanup (90+ days)
+    └── validate-*.yml        # Targeted file validation (Brewfile, Flatpak, Justfile, Renovate)
+```
+
+## Release Workflow
+
+1. Open changes against `main`.
+2. Merge only after required validation and image build checks pass.
+3. Test `ghcr.io/OWNER/IMAGE:stable-testing`.
+4. Review the pull[bot] promotion PR from `main` to `stable`.
+5. Merge the promotion to publish `ghcr.io/OWNER/IMAGE:stable`.
+
+### Image Tags Reference
+
+| Branch   | Image tag         | Audience                       |
+| -------- | ----------------- | ------------------------------ |
+| `main`   | `:stable-testing` | Testers and release candidates |
+| `stable` | `:stable`         | Production systems             |
+
+Mutable aliases: `main` also publishes `:stable-testing-<version>` and
+`:stable-testing-<date>`; `stable` publishes `:stable-daily`, `:stable-<version>`
+and `:stable-<date>` aliases. Never point production systems at anything other
+than `:stable`.
+
 ## CRITICAL: GitHub API Usage
 
 **ALWAYS use GitHub API for external references:**
@@ -60,11 +100,13 @@ links lives in `.agents/skills/README.md`.
 5. **ALWAYS** use `-y` flag for non-interactive installs
 6. **NEVER** use `dnf5` in ujust files — only Brewfile/Flatpak shortcuts
 7. **NEVER** push directly to `main` (only via PR with passing `validate` check)
-8. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
-9. **ALWAYS** run shellcheck/YAML validation before committing
-10. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`
-11. **ALWAYS** validate that new Flatpak IDs exist on Flathub before adding
-12. **NEVER** modify validation workflows without understanding impact on PR checks
+8. **NEVER** push directly to `stable`; promote tested `main` commits via pull[bot] (`.github/pull.yml`)
+9. **ALWAYS** target `main`, and test the `:stable-testing` image before approving promotion to `stable`
+10. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
+11. **ALWAYS** run shellcheck/YAML validation before committing
+12. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`
+13. **ALWAYS** validate that new Flatpak IDs exist on Flathub before adding
+14. **NEVER** modify validation workflows without understanding impact on PR checks
 
 ## Analysis vs Implementation
 
@@ -80,6 +122,6 @@ Assisted-by: [Model Name] via [Tool Name]
 
 ---
 
-**Last Updated**: 2026-08-05
+**Last Updated**: 2026-08-07
 **Template Version**: finpilot (Agent UX Overhaul)
 **Maintainer**: Universal Blue Community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,29 @@ Thanks for helping out!
 Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
 
 This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+
+## Agent-Driven Development Workflow
+
+This repository uses a **two-branch delivery model**: `main` is the testing
+branch and `stable` is the production branch. pull[bot] promotes tested
+commits from `main` to `stable` (see `.github/pull.yml`).
+
+The 8-step workflow:
+
+1. Create a focused feature branch from `main`.
+2. Use [Conventional Commits](.github/commit-convention.md) for every commit.
+3. Open a pull request targeting `main`, never `stable`.
+4. Merge after all required validation and build checks pass.
+5. Verify the new `:stable-testing` image published from `main`.
+6. Wait for pull[bot] to open a promotion pull request from `main` to `stable`.
+7. Review and approve the promotion only after the candidate has been tested.
+8. Merge the promotion to publish the production `:stable` image.
+
+**For AI agents:** Always target `main`, use Conventional Commits, follow the
+validation instructions in `AGENTS.md` (shellcheck/YAML checks before
+committing), and never push directly to `stable`. Production promotion is left
+to a human reviewer.
+
+**For humans:** Review feature pull requests, test `:stable-testing` on a real
+machine before approving, and merge pull[bot] promotion pull requests only
+when the candidate is ready for production.

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,7 @@
 export IMAGE_NAME := env("IMAGE_NAME", "finpilot")
+
+# CI overrides to "stable-testing" on main branch
+
 export DEFAULT_TAG := env("DEFAULT_TAG", "stable")
 export PODMAN := env("PODMAN", "podman")
 export REPO_ORG := env("GITHUB_REPOSITORY_OWNER", "projectbluefin")
@@ -177,6 +180,7 @@ build $target_image=IMAGE_NAME $tag=DEFAULT_TAG:
         .
 
 # Tag images with the generated alias tags
+
 # Bluefin pattern: separate tagging from pushing
 [group('Image')]
 tag-images $image_name="" $default_tag="" $tags="":

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ Use this prompt first to get your fork building:
 Bootstrap a new custom OS from @projectbluefin/finpilot. Name it after this repository. Use the `finpilot-onboarding` skill first, then:
 1. Rename `finpilot` in the 7 required files
 2. Enable GitHub Actions and set RENOVATE_TOKEN (repo + workflow scopes)
-3. Configure branch protection for `main` with `validate` as a required status check
-4. Enable auto-merge
-5. Trigger the first green build on `main`
-6. Add the "What Makes this Raptor Different" section to README.md (with placeholders)
+3. Create the `stable` branch from `main`
+4. Replace `OWNER` in `.github/pull.yml` and install the pull GitHub App
+5. Protect `main` (with `validate` required) and `stable`
+6. Enable auto-merge
+7. Trigger the first green build on `main`
+8. Add the "What Makes this Raptor Different" section to README.md (with placeholders)
 ```
 
 ### Phase 2 — Customize
@@ -68,6 +70,7 @@ Use the `finpilot-packages` and `finpilot-custom` skills, then:
 5. Update the README "What Makes this Raptor Different" section with the new entries
 6. Run `just build && just build-qcow2 && just run-vm-qcow2` to verify locally
 7. Open a PR and merge once `validate` passes
+8. Test the `:stable-testing` image, then approve the pull[bot] promotion PR
 ```
 
 ### Phase 3 — Production
@@ -88,9 +91,11 @@ Use the `finpilot-maintain` and `finpilot-ci` skills, then:
 - Automated builds via GitHub Actions on every commit
 - Self-hosted Renovate for automated dependency updates
 - Automatic cleanup of old images (90+ days) to keep it tidy
-- Pull request workflow - test changes before merging to main
-  - PRs build and validate before merge
-  - `main` branch builds `:stable` images
+- Two-branch delivery with pull[bot] promotion (bluefin-lts pattern)
+  - Pull requests target `main` and build/validate before merge
+  - `main` publishes candidate images as `:stable-testing`
+  - pull[bot] opens promotion PRs from `main` to `stable`
+  - `stable` publishes production images as `:stable`
 - Validates your files on pull requests so you never break a build:
   - Brewfile, Justfile, ShellCheck, Renovate config, and it'll even check to make sure the flatpak you add exists on FlatHub
 - Production Grade Features
@@ -146,11 +151,34 @@ Important: Change `finpilot` to your repository name in these 7 files:
 - Go to the "Actions" tab in your repository
 - Click "I understand my workflows, go ahead and enable them"
 
-Your first build will start automatically!
+Your first testing build will start automatically and publish `:stable-testing`.
 
 Note: Image signing is disabled by default. Your images will build successfully without any signing keys. Once you're ready for production, see "Optional: Enable Image Signing" below.
 
-### 4. Enable Renovate (Required)
+### 4. Configure Testing and Stable Branches
+
+This template uses a **two-branch model**: `main` publishes `:stable-testing`
+candidate images and `stable` publishes `:stable` production images. pull[bot]
+promotes tested commits from `main` to `stable`.
+
+Create the production branch from `main`:
+
+```bash
+git switch main
+git switch -c stable
+git push --set-upstream origin stable
+git switch main
+```
+
+Replace both `OWNER` placeholders in `.github/pull.yml` with your GitHub
+username, then install the [pull GitHub App](https://github.com/apps/pull) for
+your repository. pull[bot] opens promotion PRs from `main` to `stable` — never
+push directly to `stable`.
+
+See the [setup checklist](.github/SETUP_CHECKLIST.md) for branch protection
+details and config validation.
+
+### 5. Enable Renovate (Required)
 
 Renovate automatically updates dependencies and GitHub Actions (including workflow files). This template uses a self-hosted Renovate runner via `projectbluefin/actions`.
 
@@ -174,7 +202,7 @@ Renovate automatically updates dependencies and GitHub Actions (including workfl
 
 Renovate will run every 6 hours and on config changes. It pins GitHub Actions to SHAs and updates tracked image digests automatically.
 
-### 5. Customize Your Image
+### 6. Customize Your Image
 
 Choose your base image in `Containerfile` (the `FROM` line):
 
@@ -197,21 +225,41 @@ Customize your apps:
 - Add Flatpaks in `custom/flatpaks/` ([guide](custom/flatpaks/README.md))
 - Add ujust commands in `custom/ujust/` ([guide](custom/ujust/README.md))
 
-### 6. Development Workflow
+### 7. Development Workflow
 
-All changes should be made via pull requests:
+| Branch   | Image tag         | Purpose                      |
+| -------- | ----------------- | ---------------------------- |
+| `main`   | `:stable-testing` | Integration and user testing |
+| `stable` | `:stable`         | Approved production releases |
 
-1. Open a pull request on GitHub with the change you want.
-2. The PR will automatically trigger:
-   - Build validation
-   - Brewfile, Flatpak, Justfile, and shellcheck validation
-   - Test image build
-3. Once checks pass, merge the PR
-4. Merging triggers publishes a `:stable` image
+All feature and Renovate pull requests target `main`:
 
-### 7. Deploy Your Image
+1. Create a feature branch and open a pull request to `main`.
+2. Wait for build, Brewfile, Flatpak, Justfile, and shell validation.
+3. Merge the pull request to publish `:stable-testing`.
+4. Test the candidate image:
 
-Switch to your image:
+   ```bash
+   sudo bootc switch ghcr.io/your-username/your-repo-name:stable-testing
+   sudo systemctl reboot
+   ```
+
+5. Review the promotion PR that pull[bot] opens from `main` to `stable`.
+6. Approve and merge it to publish `:stable`.
+
+Never push directly to `stable`; pull[bot] manages it with a `hardreset`
+promotion strategy.
+
+### 8. Deploy Your Image
+
+Test the current candidate from `main`:
+
+```bash
+sudo bootc switch ghcr.io/your-username/your-repo-name:stable-testing
+sudo systemctl reboot
+```
+
+Deploy the promoted production image from `stable`:
 
 ```bash
 sudo bootc switch ghcr.io/your-username/your-repo-name:stable
@@ -254,6 +302,12 @@ cosign verify \
 Ready to take your custom OS to production? Enable these features for enhanced security, reliability, and performance:
 
 ### Production Checklist
+
+- [ ] **Configure Testing-to-Stable Promotion**
+  - Create `stable` from `main`
+  - Replace `OWNER` in `.github/pull.yml`
+  - Install the [pull GitHub App](https://github.com/apps/pull)
+  - Protect `stable` from direct pushes
 
 - [ ] **Enable Image Signing** (Recommended)
   - Provides cryptographic verification of your images


### PR DESCRIPTION
## Summary

Implements #57: two-branch delivery model mirroring [ublue-os/bluefin-lts](https://github.com/ublue-os/bluefin-lts):

- `main` = testing branch → publishes `:stable-testing` images
- `stable` = production branch → publishes `:stable` images
- [pull[bot]](https://github.com/apps/pull) promotes tested commits `main → stable` via `.github/pull.yml` (hardreset, `mergeUnstable: false`)

## Changes

| File | Change |
| --- | --- |
| `.github/pull.yml` | **new** — pull[bot] config (reviewers: `OWNER` placeholder for forks to replace) |
| `.github/workflows/build-image.yml` | dual-branch triggers (push/PR to main+stable, `merge_group`), removed `schedule` cron per issue design decision, `PRODUCTION_BRANCH`/`TESTING_BRANCH` env, `Determine image tag` + `Finalize branch tags` steps, relaxed publish guards to `github.event_name != 'pull_request'` |
| `.github/SETUP_CHECKLIST.md` | stable branch creation, pull app install, OWNER replacement, delivery flow diagram, both-tag deploy commands |
| `README.md` | branch/tag table, dev workflow steps, testing + production deploy commands |
| `AGENTS.md` | branch strategy, CI structure, release workflow, image tag reference, updated critical rules |
| `CONTRIBUTING.md` | agent-driven development workflow (8-step) |
| `.agents/skills/finpilot-ci/SKILL.md` | workflow map + branch promotion/tag notes |
| `Justfile` | comment documenting the CI `DEFAULT_TAG` override |

## Tag logic (verified by simulation)

`generate-tags` treats any stream containing "stable" as a stable stream (emits `stable-daily*`), so the naive `DEFAULT_TAG=-testing` append would collide testing and production tags. The workflow therefore uses a separate `TAG_STREAM` (`testing`/`stable`) and a `Finalize branch tags` step that renames `testing*` → `stable-testing-*`:

```
main push:   stable-testing stable-testing-44.20250807 stable-testing-20250807
stable push: stable-daily 44.20250807 stable-daily-44.20250807 stable-daily-20250807 stable
stable dispatch: + stable-44.20250807 gts gts-44.20250807 (promotion tags)
```

## Validation

- PyYAML parse of all workflows + `pull.yml` ✓
- `bash -n` + shellcheck on the new run blocks (SC2148/SC2153 are Actions-context false positives) ✓
- `just --unstable --fmt --check -f Justfile` ✓ (also fixes a pre-existing fmt violation so `just check` passes)
- `just --list` ✓
- `git diff --check` ✓
- shellcheck `build/*.sh` ✓

## Notes / decisions

- **Cron removed** per the issue's explicit design decision ("no cron", matching latest bluefin-lts). Trade-off: without a daily scheduled build, base-image security updates are picked up on the next push to `main`/`stable`; a separate `scheduled-*` workflow can be added later if daily rebuilds are wanted.
- **`OWNER` reviewer placeholder** kept per the issue spec; forks replace it during setup (documented in SETUP_CHECKLIST/README). If pull[bot] is installed on this repo, replace `OWNER` with a real username before/after merge.
- **`stable` branch**: created in this fork (`hanthor/finpilot:stable` = copy of this branch). Upstream `projectbluefin/finpilot` needs a `stable` branch created after merge (one-time, per SETUP_CHECKLIST step 3).
- Existing PRs #231/#232 also target this issue; this PR is an independent, fully-validated implementation based on current `main`.

Closes #57