### PR TITLE
fix(ci): harden workflow security — pin renovate, add clean.yml permissions

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 0 * * 0" # Weekly on Sunday at midnight UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
 
@@ -11,6 +14,7 @@ jobs:
   delete-older-than-90:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
     steps:
       - name: Checkout

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           node-version: latest
 
-      - run: npm install -g renovate@latest
+      - env:
+          # renovate: datasource=npm depName=renovate
+          RENOVATE_VERSION: "44.14.10"
+        run: npm install -g "renovate@${RENOVATE_VERSION}"
 
       - run: renovate-config-validator .github/renovate.json


### PR DESCRIPTION
## Summary

Two security-review fixes:

### #236 — validate-renovate.yml unpinned `renovate@latest`
Installing renovate via `npm install -g renovate@latest` on a pull_request-triggered path is a supply-chain risk. Pinned to **44.14.10** (current) via a `RENOVATE_VERSION` env var with a Renovate tracking comment:

```yaml
env:
  # renovate: datasource=npm depName=renovate
  RENOVATE_VERSION: "44.14.10"
run: npm install -g "renovate@${RENOVATE_VERSION}"
```

The comment matches the existing regex custom manager in `.github/renovate.json` ("Track pinned tool versions in workflow env vars"), so Renovate will open update PRs for it. `renovate.json` itself was not modified per repo rules.

### #238 — clean.yml missing permissions block
Added a top-level `permissions: contents: read` block and explicit `contents: read` on the job (required for checkout). The job retains only `packages: write` for the GHCR cleanup action — no other scopes granted.

## Validation
- `actionlint` clean on both files
- YAML parse clean

Closes #236
Closes #238