### PR TITLE
ci: add two-branch main/stable workflow with factory promotion reusable

### DIFF
--- a/.agents/skills/finpilot-ci/SKILL.md
+++ b/.agents/skills/finpilot-ci/SKILL.md
@@ -31,16 +31,32 @@ description: >-
 
 ## Workflow Map
 
-| File                     | Trigger                           | Purpose                                              |
-| ------------------------ | --------------------------------- | ---------------------------------------------------- |
-| `build-image.yml`        | push main, schedule, manual       | Build + push `:stable` via `projectbluefin/actions`  |
-| `pr-validation.yml`      | PR → main                         | shellcheck + hadolint + pre-commit via `validate-pr` |
-| `renovate.yml`           | schedule 6h, push renovate config | Self-hosted Renovate runner                          |
-| `clean.yml`              | schedule weekly                   | Delete GHCR images older than 90 days                |
-| `validate-brewfiles.yml` | PR paths: `custom/brew/**`        | Homebrew Brewfile syntax check                       |
-| `validate-flatpaks.yml`  | PR paths: `custom/flatpaks/**`    | Flathub app ID existence check                       |
-| `validate-justfiles.yml` | PR paths: `Justfile`              | `just --list` syntax check                           |
-| `validate-renovate.yml`  | PR paths: `.github/renovate.json` | `renovate-config-validator`                          |
+| File                          | Trigger                           | Purpose                                                       |
+| ----------------------------- | --------------------------------- | ------------------------------------------------------------- |
+| `build-image.yml`             | push main + stable, manual        | Publish `:stable-testing` (main) or `:stable` (stable)        |
+| `promote-main-to-stable.yml`  | push main, manual                 | Squash promotion PR `main` → `stable` via factory reusable    |
+| `sync-stable-to-main.yml`     | push stable                       | Merge direct `stable` hotfixes back to `main` (usually no-op) |
+| `pr-validation.yml`           | PR → main                         | shellcheck + hadolint + pre-commit via `validate-pr`          |
+| `renovate.yml`                | schedule 6h, push renovate config | Self-hosted Renovate runner                                   |
+| `clean.yml`                   | schedule weekly                   | Delete GHCR images older than 90 days                         |
+| `validate-brewfiles.yml`      | PR paths: `custom/brew/**`        | Homebrew Brewfile syntax check                                |
+| `validate-flatpaks.yml`       | PR paths: `custom/flatpaks/**`    | Flathub app ID existence check                                |
+| `validate-justfiles.yml`      | PR paths: `Justfile`              | `just --list` syntax check                                    |
+| `validate-renovate.yml`       | PR paths: `.github/renovate.json` | `renovate-config-validator`                                   |
+
+## Branch Promotion and Tags
+
+- `main` is the testing branch and publishes `:stable-testing` (plus bare
+  `:testing`, which the promotion release gate resolves).
+- `stable` is the production branch and publishes `:stable`.
+- Promotion uses `reusable-promote-squash.yml` and `reusable-sync-branches.yml`
+  from `projectbluefin/actions` — the factory contract. pull[bot] /
+  `.github/pull.yml` was rejected (issues #235/#237); do not add it.
+- The `Determine image tag` step sets `TAG_STREAM=testing` off the production
+  branch; `Finalize branch tags` renames `testing*` tags to `stable-testing-*`
+  so they never collide with production `stable-daily*` aliases.
+- The release gate verifies cosign signatures on `:testing`; keyless signing
+  (optional step in `build-image.yml`) must be enabled for `release/ready`.
 
 ## Composite Action Pins
 

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -20,7 +20,28 @@
 - [ ] Settings → Actions → General → Enable workflows
 - [ ] Set "Read and write permissions"
 
-### 3. First Push
+### 3. Configure Testing and Production Branches
+
+This template uses a **two-branch model**: `main` publishes `:stable-testing`
+candidate images, and `stable` publishes `:stable` production images.
+Promotion is a squash PR from `main` to `stable` opened automatically by
+`.github/workflows/promote-main-to-stable.yml` (factory reusable workflow —
+no external GitHub App required).
+
+Create `stable` as an exact copy of `main`, then return to `main`:
+
+```bash
+git switch main
+git switch -c stable
+git push --set-upstream origin stable
+git switch main
+```
+
+- [ ] Never commit directly to `stable`; it receives only promotion PRs
+- [ ] Enable keyless signing (see "Enable Signing" below) so the promotion
+      release gate can verify image signatures and report `release/ready`
+
+### 4. First Push
 
 ```bash
 git add .
@@ -28,7 +49,7 @@ git commit -m "feat: initial customization"
 git push origin main
 ```
 
-### 4. Enable Renovate (Required)
+### 5. Enable Renovate (Required)
 
 - [ ] Create a **Classic PAT** (Settings → Developer settings → Personal access tokens → Tokens (classic))
   - Scopes: `repo` (full control) + `workflow` (update workflows)
@@ -41,11 +62,15 @@ git push origin main
   - Enable "Require status checks to pass before merging"
   - Add `validate` as a required status check
   - Enable "Require branches to be up to date before merging"
+- [ ] Configure branch protection for `stable`: require a pull request before
+      merging so only promotion PRs land there
 - [ ] Renovate will create a PR to pin your GitHub Actions to SHAs
+
+Renovate targets `main`; approved changes reach `stable` through the promotion flow.
 
 **Agent skills:** `finpilot-onboarding` (branch protection), `finpilot-ci` (Renovate config)
 
-### 5. Add "What Makes this Raptor Different" to README
+### 6. Add "What Makes this Raptor Different" to README
 
 - [ ] Open `README.md`
 - [ ] Paste the raptor section template (see README or use the `finpilot-onboarding` skill)
@@ -54,7 +79,16 @@ git push origin main
 
 **Agent skills:** `finpilot-onboarding` (raptor section), `finpilot-maintain` (maintenance requirement)
 
-### 6. Deploy
+### 7. Deploy
+
+Test the candidate image from `main`:
+
+```bash
+sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable-testing
+sudo systemctl reboot
+```
+
+After merging the promotion to `stable`, deploy the production image:
 
 ```bash
 sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable
@@ -93,8 +127,9 @@ Which skill to load for each checklist block above:
 | ------------------------------------- | ------------------------------------------- |
 | Rename (step 1)                       | `finpilot-templates`, `finpilot-onboarding` |
 | Enable Actions (step 2)               | `finpilot-onboarding`                       |
-| Renovate + branch protection (step 4) | `finpilot-onboarding`, `finpilot-ci`        |
-| Raptor section (step 5)               | `finpilot-onboarding`, `finpilot-maintain`  |
+| Branches + promotion (step 3)         | `finpilot-onboarding`, `finpilot-ci`        |
+| Renovate + branch protection (step 5) | `finpilot-onboarding`, `finpilot-ci`        |
+| Raptor section (step 6)               | `finpilot-onboarding`, `finpilot-maintain`  |
 | Signing (optional)                    | `finpilot-templates`                        |
 | Rechunking (optional)                 | `finpilot-ci`                               |
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,6 +1,12 @@
 ---
 name: Build and Push Image
 
+# Two-branch model:
+#   main   = testing branch, publishes :stable-testing (plus :testing for the
+#            factory release gate)
+#   stable = production branch, publishes :stable
+# promote-main-to-stable.yml opens the main -> stable promotion PR.
+#
 # PR builds are disabled by default to save CI minutes. To enable them, add:
 #   pull_request:
 #     branches:
@@ -12,11 +18,10 @@ on:
   push:
     branches:
       - main
+      - stable
     paths-ignore:
       - "**.md"
       - ".github/workflows/*validate*.yml"
-  schedule:
-    - cron: "05 10 * * *" # 10:05am UTC everyday
   workflow_dispatch:
 
 permissions:
@@ -33,6 +38,7 @@ env:
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
   DEFAULT_TAG: "stable"
+  PRODUCTION_BRANCH: "stable" # The branch that publishes :stable production images
   REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
   ENABLE_RECHUNKING: "false"
   RECHUNK_MAX_LAYERS: "128"
@@ -55,8 +61,27 @@ jobs:
     steps:
       - name: Prepare environment
         run: |
-          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
-          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> "${GITHUB_ENV}"
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "${GITHUB_ENV}"
+
+      # Anything not on the production branch is a testing build. TAG_STREAM
+      # keeps generate-tags on the "testing" stream so it never emits
+      # stable-daily* aliases that would collide with production; the
+      # Finalize branch tags step renames them to stable-testing-*.
+      - name: Determine image tag
+        id: determine-tag
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]]; then
+            echo "DEFAULT_TAG=${DEFAULT_TAG}-testing" >> "${GITHUB_ENV}"
+            echo "TAG_STREAM=testing" >> "${GITHUB_ENV}"
+            echo "Building testing image: ${DEFAULT_TAG}-testing"
+          else
+            echo "TAG_STREAM=${DEFAULT_TAG}" >> "${GITHUB_ENV}"
+            echo "Building production image: ${DEFAULT_TAG}"
+          fi
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -122,7 +147,7 @@ jobs:
         run: |
           VERSION_LABEL=$(sudo podman inspect "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
             --format '{{index .Config.Labels "org.opencontainers.image.version"}}')
-          echo "version=${VERSION_LABEL}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION_LABEL}" >> "${GITHUB_OUTPUT}"
           echo "Version: ${VERSION_LABEL}"
 
       - name: Generate tags
@@ -131,10 +156,49 @@ jobs:
         uses: projectbluefin/actions/bootc-build/generate-tags@5fe9b3bcfdf3a68b4d2eb459445505b600e456e6 # v1
         with:
           base-name: ${{ env.IMAGE_NAME }}
-          stream-name: ${{ env.DEFAULT_TAG }}
+          stream-name: ${{ env.TAG_STREAM }}
           version-label: ${{ steps.version.outputs.version }}
           event-name: ${{ github.event_name }}
           pr-number: ${{ github.event.number }}
+
+      # generate-tags emits stream-native tags (testing* or stable-daily* plus
+      # version aliases). For testing builds this renames testing* tags to
+      # stable-testing-*, keeps the bare :testing tag (the factory release
+      # gate in reusable-promote-squash.yml resolves digests from it), and
+      # guarantees the mutable consumer tag (:stable / :stable-testing) is
+      # always published.
+      - name: Finalize branch tags
+        if: steps.detect-changes.outputs.should_build == 'true' || github.event_name != 'pull_request'
+        id: branch-tags
+        shell: bash
+        env:
+          GENERATED_TAGS: ${{ steps.generate-tags.outputs.tags }}
+        run: |
+          read -r -a generated_tags <<< "${GENERATED_TAGS}"
+          branch_tags=()
+
+          add_tag() {
+            local candidate="$1"
+            local existing
+            for existing in "${branch_tags[@]}"; do
+              [[ "${existing}" == "${candidate}" ]] && return
+            done
+            branch_tags+=("${candidate}")
+          }
+
+          for tag in "${generated_tags[@]}"; do
+            if [[ "${TAG_STREAM}" == "testing" ]]; then
+              # Bare :testing stays so the promotion release gate can resolve it.
+              [[ "${tag}" == "testing" ]] && add_tag "${tag}"
+              add_tag "${tag/testing/stable-testing}"
+            else
+              add_tag "${tag}"
+            fi
+          done
+          add_tag "${DEFAULT_TAG}"
+
+          echo "tags=${branch_tags[*]}" >> "${GITHUB_OUTPUT}"
+          echo "default-tag=${DEFAULT_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Save DNF cache
         if: always() && !cancelled() && github.event_name != 'pull_request'
@@ -159,14 +223,16 @@ jobs:
         if: github.event_name != 'pull_request'
         shell: bash
         env:
-          ALIAS_TAGS: ${{ steps.generate-tags.outputs.tags }}
+          ALIAS_TAGS: ${{ steps.branch-tags.outputs.tags }}
         run: |
           sudo -E "$(command -v just)" tag-images "${IMAGE_NAME}" \
                           "${DEFAULT_TAG}" \
                           "${ALIAS_TAGS}"
 
+      # Publish from both the testing (main) and production (stable) branches;
+      # PR builds only build and validate, they never publish.
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
@@ -174,13 +240,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GHCR
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         id: push
         uses: projectbluefin/actions/bootc-build/push-image@5fe9b3bcfdf3a68b4d2eb459445505b600e456e6 # v1
         with:
           image-name: ${{ env.IMAGE_NAME }}
-          tags: ${{ steps.generate-tags.outputs.tags }}
-          default-tag: ${{ steps.generate-tags.outputs.default-tag }}
+          tags: ${{ steps.branch-tags.outputs.tags }}
+          default-tag: ${{ steps.branch-tags.outputs.default-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # OPTIONAL: Sign and attest (SLSA Build L2 provenance)

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -1,0 +1,47 @@
+---
+name: Promote main to stable
+
+# Two-branch model: `main` is the testing branch (publishes :stable-testing),
+# `stable` is the production branch (publishes :stable). On every push to
+# `main` the shared factory workflow opens (or refreshes) a squash promotion
+# PR from `main` to `stable`; merging it publishes :stable.
+#
+# Reusable logic lives in projectbluefin/actions — this is a thin caller,
+# matching the pattern in projectbluefin/bluefin and projectbluefin/bluefin-lts.
+# pull[bot] was considered and rejected: the factory reusable is auditable,
+# org-maintained, and shared with the other image repos (see issues #235/#237).
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+  statuses: write
+
+concurrency:
+  group: promote-main-to-stable
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote main to stable
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@f8418f73faf163c048ab23f10655235c078d7606 # v1
+    with:
+      variants: >-
+        [{"image":"${{ github.event.repository.name }}"}]
+      cosign_identity_regexp: >-
+        ^https://github\.com/${{ github.repository_owner }}/[^/]+/\.github/workflows/
+      registry: ghcr.io/${{ github.repository_owner }}
+      source_branch: main
+      target_branch: stable
+      # The release gate resolves the :testing tag (published by main builds)
+      # and verifies its cosign signature. Enable the OPTIONAL keyless signing
+      # step in build-image.yml for the gate to report release/ready.
+      run_e2e: false
+    secrets: inherit

--- a/.github/workflows/sync-stable-to-main.yml
+++ b/.github/workflows/sync-stable-to-main.yml
@@ -1,0 +1,32 @@
+---
+name: Sync stable to main
+
+# After each squash-merge promotion (main → stable), the squash commit exists
+# only on stable. Since the trees are identical this workflow normally no-ops;
+# if a hotfix ever lands on stable directly, it is merged back into main so
+# the next promotion PR is not blocked.
+#
+# Thin caller for the factory reusable in projectbluefin/actions, matching
+# bluefin's sync-main-to-testing.yml.
+
+on:
+  push:
+    branches:
+      - stable
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-stable-to-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Keep main up-to-date with stable
+    uses: projectbluefin/actions/.github/workflows/reusable-sync-branches.yml@f8418f73faf163c048ab23f10655235c078d7606 # v1
+    permissions:
+      contents: write
+    with:
+      source_branch: stable
+      target_branch: main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,37 @@ domain skill, and finish with `finpilot-pr-checklist`. Not sure which skill
 fits? Load `finpilot-router` — it owns the routing table. The skill index with
 links lives in `.agents/skills/README.md`.
 
+## Branch Strategy
+
+- `main` is the **testing branch** — all feature and Renovate PRs land here,
+  and pushes publish `:stable-testing` images.
+- `stable` is the **production branch** — pushes publish `:stable` images.
+- Promotion is `main` → `stable` via squash PRs opened by
+  `.github/workflows/promote-main-to-stable.yml`, a thin caller of the factory
+  reusable `projectbluefin/actions/.github/workflows/reusable-promote-squash.yml`.
+  `sync-stable-to-main.yml` (`reusable-sync-branches.yml`) merges any direct
+  `stable` hotfixes back into `main`.
+- Decision record: the factory reusable workflow was chosen over the external
+  pull[bot] app (issues #235/#237). Do not add `.github/pull.yml`.
+- Never commit directly to `stable`; it receives only promotion PRs.
+
+## Release Workflow
+
+1. Open changes against `main`.
+2. Merge only after required validation and image build checks pass.
+3. Test `ghcr.io/OWNER/IMAGE:stable-testing`.
+4. Review the auto-opened promotion PR from `main` to `stable`.
+5. Merge the promotion to publish `ghcr.io/OWNER/IMAGE:stable`.
+
+| Branch   | Image tag         | Audience                       |
+| -------- | ----------------- | ------------------------------ |
+| `main`   | `:stable-testing` | Testers and release candidates |
+| `stable` | `:stable`         | Production systems             |
+
+The promotion release gate verifies cosign signatures on the `:testing` tag;
+enable keyless signing (SETUP_CHECKLIST "Enable Signing") for it to report
+`release/ready`.
+
 ## CRITICAL: GitHub API Usage
 
 **ALWAYS use GitHub API for external references:**
@@ -60,6 +91,8 @@ links lives in `.agents/skills/README.md`.
 5. **ALWAYS** use `-y` flag for non-interactive installs
 6. **NEVER** use `dnf5` in ujust files — only Brewfile/Flatpak shortcuts
 7. **NEVER** push directly to `main` (only via PR with passing `validate` check)
+8. **NEVER** push directly to `stable`; promote tested `main` commits via the promotion PR from `promote-main-to-stable.yml`
+9. **ALWAYS** test the `:stable-testing` image before merging a promotion to `stable`
 8. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
 9. **ALWAYS** run shellcheck/YAML validation before committing
 10. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`


### PR DESCRIPTION
## Summary

Canonical implementation of #57, resolving the three-way PR arbitration (#237) and the architecture finding (#235).

**Decision:** none of #231 / #232 / #234 is adopted. All three use the external pull[bot] app; the factory contract is `reusable-promote-squash.yml` in `projectbluefin/actions` (used by bluefin and bluefin-lts). This PR implements the two-branch model as thin callers of the factory reusables, SHA-pinned with version comments, and adopts the branch-aware tag logic from #234 (the strongest of the three) for `build-image.yml`.

## Changes

- **`promote-main-to-stable.yml`** — thin caller of `reusable-promote-squash.yml@f8418f7` (# v1). On push to `main`, opens/refreshes a squash promotion PR `main` → `stable` with auto-merge enabled.
- **`sync-stable-to-main.yml`** — thin caller of `reusable-sync-branches.yml@f8418f7` (# v1). No-ops when trees are identical; merges any direct `stable` hotfix back into `main`.
- **`build-image.yml`** — builds on push to `main` and `stable`; `main` publishes `:stable-testing` (plus bare `:testing`, which the promotion release gate resolves), `stable` publishes `:stable`. Daily cron removed per the #57 design table.
- **Docs** — branch strategy + decision record in `AGENTS.md`, `stable` branch setup in `SETUP_CHECKLIST.md`, workflow map update in the `finpilot-ci` skill.

## Notes

- The promotion release gate verifies cosign signatures on `:testing`; until the optional keyless-signing step is enabled, promotion PRs will be labeled `release/blocked` but remain manually mergeable.
- The reusable requests review from `<owner>/maintainers` on promotion PRs — forks without that team get a warning, not a failure.
- Validated with `actionlint` and YAML parse on all touched workflows.

Closes #57
Closes #235
Closes #237

Assisted-by: Kimi K3 via GitHub Copilot CLI