### PR TITLE
ci: add two-branch main/stable workflow with factory promotion

### DIFF
--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -20,7 +20,28 @@
 - [ ] Settings → Actions → General → Enable workflows
 - [ ] Set "Read and write permissions"
 
-### 3. First Push
+### 3. Configure Testing and Production Branches
+
+This template uses a **two-branch model**: `main` publishes `:stable-testing`
+candidate images, and `stable` publishes `:stable` production images.
+Promotion is a squash PR from `main` to `stable` opened automatically by
+`.github/workflows/promote-main-to-stable.yml` (factory reusable workflow —
+no external GitHub App required).
+
+Create `stable` as an exact copy of `main`, then return to `main`:
+
+```bash
+git switch main
+git switch -c stable
+git push --set-upstream origin stable
+git switch main
+```
+
+- [ ] Never commit directly to `stable`; it receives only promotion PRs
+- [ ] Enable keyless signing (see "Enable Signing" below) so the promotion
+      release gate can verify image signatures and report `release/ready`
+
+### 4. First Push
 
 ```bash
 git add .
@@ -28,7 +49,7 @@ git commit -m "feat: initial customization"
 git push origin main
 ```
 
-### 4. Enable Renovate (Required)
+### 5. Enable Renovate (Required)
 
 - [ ] Create a **Classic PAT** (Settings → Developer settings → Personal access tokens → Tokens (classic))
   - Scopes: `repo` (full control) + `workflow` (update workflows)
@@ -41,11 +62,15 @@ git push origin main
   - Enable "Require status checks to pass before merging"
   - Add `validate` as a required status check
   - Enable "Require branches to be up to date before merging"
+- [ ] Configure branch protection for `stable`: require a pull request before
+      merging so only promotion PRs land there
 - [ ] Renovate will create a PR to pin your GitHub Actions to SHAs
+
+Renovate targets `main`; approved changes reach `stable` through the promotion flow.
 
 **Agent skills:** `finpilot-onboarding` (branch protection), `finpilot-ci` (Renovate config)
 
-### 5. Add "What Makes this Raptor Different" to README
+### 6. Add "What Makes this Raptor Different" to README
 
 - [ ] Open `README.md`
 - [ ] Paste the raptor section template (see README or use the `finpilot-onboarding` skill)
@@ -54,7 +79,16 @@ git push origin main
 
 **Agent skills:** `finpilot-onboarding` (raptor section), `finpilot-maintain` (maintenance requirement)
 
-### 6. Deploy
+### 7. Deploy
+
+Test the candidate image from `main`:
+
+```bash
+sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable-testing
+sudo systemctl reboot
+```
+
+After merging the promotion to `stable`, deploy the production image:
 
 ```bash
 sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable
@@ -93,8 +127,9 @@ Which skill to load for each checklist block above:
 | ------------------------------------- | ------------------------------------------- |
 | Rename (step 1)                       | `finpilot-templates`, `finpilot-onboarding` |
 | Enable Actions (step 2)               | `finpilot-onboarding`                       |
-| Renovate + branch protection (step 4) | `finpilot-onboarding`, `finpilot-ci`        |
-| Raptor section (step 5)               | `finpilot-onboarding`, `finpilot-maintain`  |
+| Branches + promotion (step 3)         | `finpilot-onboarding`, `finpilot-ci`        |
+| Renovate + branch protection (step 5) | `finpilot-onboarding`, `finpilot-ci`        |
+| Raptor section (step 6)               | `finpilot-onboarding`, `finpilot-maintain`  |
 | Signing (optional)                    | `finpilot-templates`                        |
 | Rechunking (optional)                 | `finpilot-ci`                               |
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,22 +1,30 @@
 ---
 name: Build and Push Image
 
-# PR builds are disabled by default to save CI minutes. To enable them, add:
-#   pull_request:
-#     branches:
-#       - main
-#     paths-ignore:
-#       - "**.md"
-#       - ".github/workflows/*validate*.yml"
+# Two-branch model:
+#   main   = testing branch, publishes :stable-testing (plus :testing for the
+#            factory release gate)
+#   stable = production branch, publishes :stable
+# promote-main-to-stable.yml opens the main -> stable promotion PR.
+#
+# Pull requests build without publishing; pushes to either branch publish
+# branch-specific image tags.
 on:
-  push:
+  pull_request:
     branches:
       - main
+      - stable
     paths-ignore:
       - "**.md"
       - ".github/workflows/*validate*.yml"
-  schedule:
-    - cron: "05 10 * * *" # 10:05am UTC everyday
+  push:
+    branches:
+      - main
+      - stable
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*validate*.yml"
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -33,6 +41,8 @@ env:
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
   DEFAULT_TAG: "stable"
+  PRODUCTION_BRANCH: "stable" # The branch that publishes :stable production images
+  TESTING_BRANCH: "main" # The branch that publishes :stable-testing images
   REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
   ENABLE_RECHUNKING: "false"
   RECHUNK_MAX_LAYERS: "128"
@@ -55,8 +65,29 @@ jobs:
     steps:
       - name: Prepare environment
         run: |
-          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
-          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> "${GITHUB_ENV}"
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "${GITHUB_ENV}"
+
+      # Anything not on the production branch is a testing build. TAG_STREAM
+      # keeps generate-tags on the "testing" stream so it never emits
+      # stable-daily* aliases that would collide with production; the
+      # Finalize branch tags step renames them to stable-testing-*.
+      # This mirrors the branch-aware tagging contract in the factory build
+      # workflow (projectbluefin/actions).
+      - name: Determine image tag
+        id: determine-tag
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]]; then
+            echo "DEFAULT_TAG=${DEFAULT_TAG}-testing" >> "${GITHUB_ENV}"
+            echo "TAG_STREAM=testing" >> "${GITHUB_ENV}"
+            echo "Building testing image: ${DEFAULT_TAG}-testing"
+          else
+            echo "TAG_STREAM=${DEFAULT_TAG}" >> "${GITHUB_ENV}"
+            echo "Building production image: ${DEFAULT_TAG}"
+          fi
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -122,7 +153,7 @@ jobs:
         run: |
           VERSION_LABEL=$(sudo podman inspect "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
             --format '{{index .Config.Labels "org.opencontainers.image.version"}}')
-          echo "version=${VERSION_LABEL}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION_LABEL}" >> "${GITHUB_OUTPUT}"
           echo "Version: ${VERSION_LABEL}"
 
       - name: Generate tags
@@ -131,10 +162,49 @@ jobs:
         uses: projectbluefin/actions/bootc-build/generate-tags@5fe9b3bcfdf3a68b4d2eb459445505b600e456e6 # v1
         with:
           base-name: ${{ env.IMAGE_NAME }}
-          stream-name: ${{ env.DEFAULT_TAG }}
+          stream-name: ${{ env.TAG_STREAM }}
           version-label: ${{ steps.version.outputs.version }}
           event-name: ${{ github.event_name }}
           pr-number: ${{ github.event.number }}
+
+      # generate-tags emits stream-native tags (testing* or stable-daily* plus
+      # version aliases). For testing builds this renames testing* tags to
+      # stable-testing-*, keeps the bare :testing tag (the factory release
+      # gate in reusable-promote-squash.yml resolves digests from it), and
+      # guarantees the mutable consumer tag (:stable / :stable-testing) is
+      # always published.
+      - name: Finalize branch tags
+        if: steps.detect-changes.outputs.should_build == 'true' || github.event_name != 'pull_request'
+        id: branch-tags
+        shell: bash
+        env:
+          GENERATED_TAGS: ${{ steps.generate-tags.outputs.tags }}
+        run: |
+          read -r -a generated_tags <<< "${GENERATED_TAGS}"
+          branch_tags=()
+
+          add_tag() {
+            local candidate="$1"
+            local existing
+            for existing in "${branch_tags[@]}"; do
+              [[ "${existing}" == "${candidate}" ]] && return
+            done
+            branch_tags+=("${candidate}")
+          }
+
+          for tag in "${generated_tags[@]}"; do
+            if [[ "${TAG_STREAM}" == "testing" ]]; then
+              # Bare :testing stays so the promotion release gate can resolve it.
+              [[ "${tag}" == "testing" ]] && add_tag "${tag}"
+              add_tag "${tag/testing/stable-testing}"
+            else
+              add_tag "${tag}"
+            fi
+          done
+          add_tag "${DEFAULT_TAG}"
+
+          echo "tags=${branch_tags[*]}" >> "${GITHUB_OUTPUT}"
+          echo "default-tag=${DEFAULT_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Save DNF cache
         if: always() && !cancelled() && github.event_name != 'pull_request'
@@ -159,14 +229,16 @@ jobs:
         if: github.event_name != 'pull_request'
         shell: bash
         env:
-          ALIAS_TAGS: ${{ steps.generate-tags.outputs.tags }}
+          ALIAS_TAGS: ${{ steps.branch-tags.outputs.tags }}
         run: |
           sudo -E "$(command -v just)" tag-images "${IMAGE_NAME}" \
                           "${DEFAULT_TAG}" \
                           "${ALIAS_TAGS}"
 
+      # Publish from both the testing (main) and production (stable) branches;
+      # PR builds only build and validate, they never publish.
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
@@ -174,13 +246,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GHCR
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         id: push
         uses: projectbluefin/actions/bootc-build/push-image@5fe9b3bcfdf3a68b4d2eb459445505b600e456e6 # v1
         with:
           image-name: ${{ env.IMAGE_NAME }}
-          tags: ${{ steps.generate-tags.outputs.tags }}
-          default-tag: ${{ steps.generate-tags.outputs.default-tag }}
+          tags: ${{ steps.branch-tags.outputs.tags }}
+          default-tag: ${{ steps.branch-tags.outputs.default-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # OPTIONAL: Sign and attest (SLSA Build L2 provenance)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+      - stable
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -1,0 +1,52 @@
+---
+name: Promote main to stable
+
+# Two-branch model: `main` is the testing branch (publishes :stable-testing),
+# `stable` is the production branch (publishes :stable). On every push to
+# `main` the shared factory workflow opens (or refreshes) a squash promotion
+# PR from `main` to `stable`; merging it publishes :stable.
+#
+# Reusable logic lives in projectbluefin/actions — this is a thin caller,
+# matching the pattern in projectbluefin/bluefin and projectbluefin/bluefin-lts.
+# pull[bot] was considered and rejected: the factory reusable is auditable,
+# org-maintained, and shared with the other image repos (see issues #235/#237).
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+  statuses: write
+
+concurrency:
+  group: promote-main-to-stable
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote main to stable
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@f8418f73faf163c048ab23f10655235c078d7606 # v1
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+    with:
+      variants: >-
+        [{"image":"${{ github.event.repository.name }}"}]
+      cosign_identity_regexp: >-
+        ^https://github\.com/${{ github.repository_owner }}/[^/]+/\.github/workflows/
+      registry: ghcr.io/${{ github.repository_owner }}
+      source_branch: main
+      target_branch: stable
+      use_merge_queue: false
+      # The release gate resolves the :testing tag (published by main builds)
+      # and verifies its cosign signature. Enable the OPTIONAL keyless signing
+      # step in build-image.yml for the gate to report release/ready.
+      run_e2e: false
+    secrets: inherit

--- a/.github/workflows/sync-stable-to-main.yml
+++ b/.github/workflows/sync-stable-to-main.yml
@@ -1,0 +1,32 @@
+---
+name: Sync stable to main
+
+# After each squash-merge promotion (main → stable), the squash commit exists
+# only on stable. Since the trees are identical this workflow normally no-ops;
+# if a hotfix ever lands on stable directly, it is merged back into main so
+# the next promotion PR is not blocked.
+#
+# Thin caller for the factory reusable in projectbluefin/actions, matching
+# bluefin's sync-main-to-testing.yml.
+
+on:
+  push:
+    branches:
+      - stable
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-stable-to-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Keep main up-to-date with stable
+    uses: projectbluefin/actions/.github/workflows/reusable-sync-branches.yml@f8418f73faf163c048ab23f10655235c078d7606 # v1
+    permissions:
+      contents: write
+    with:
+      source_branch: stable
+      target_branch: main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,37 @@ domain skill, and finish with `finpilot-pr-checklist`. Not sure which skill
 fits? Load `finpilot-router` — it owns the routing table. The skill index with
 links lives in `.agents/skills/README.md`.
 
+## Branch Strategy
+
+- `main` is the **testing branch** — all feature and Renovate PRs land here,
+  and pushes publish `:stable-testing` images.
+- `stable` is the **production branch** — pushes publish `:stable` images.
+- Promotion is `main` → `stable` via squash PRs opened by
+  `.github/workflows/promote-main-to-stable.yml`, a thin caller of the factory
+  reusable `projectbluefin/actions/.github/workflows/reusable-promote-squash.yml`.
+  `sync-stable-to-main.yml` (`reusable-sync-branches.yml`) merges any direct
+  `stable` hotfixes back into `main`.
+- Decision record: the factory reusable workflow was chosen over the external
+  pull[bot] app (issues #235/#237). Do not add `.github/pull.yml`.
+- Never commit directly to `stable`; it receives only promotion PRs.
+
+## Release Workflow
+
+1. Open changes against `main`.
+2. Merge only after required validation and image build checks pass.
+3. Test `ghcr.io/OWNER/IMAGE:stable-testing`.
+4. Review the auto-opened promotion PR from `main` to `stable`.
+5. Merge the promotion to publish `ghcr.io/OWNER/IMAGE:stable`.
+
+| Branch   | Image tag         | Audience                       |
+| -------- | ----------------- | ------------------------------ |
+| `main`   | `:stable-testing` | Testers and release candidates |
+| `stable` | `:stable`         | Production systems             |
+
+The promotion release gate verifies cosign signatures on the `:testing` tag;
+enable keyless signing (SETUP_CHECKLIST "Enable Signing") for it to report
+`release/ready`.
+
 ## CRITICAL: GitHub API Usage
 
 **ALWAYS use GitHub API for external references:**
@@ -60,11 +91,13 @@ links lives in `.agents/skills/README.md`.
 5. **ALWAYS** use `-y` flag for non-interactive installs
 6. **NEVER** use `dnf5` in ujust files — only Brewfile/Flatpak shortcuts
 7. **NEVER** push directly to `main` (only via PR with passing `validate` check)
-8. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
-9. **ALWAYS** run shellcheck/YAML validation before committing
-10. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`
-11. **ALWAYS** validate that new Flatpak IDs exist on Flathub before adding
-12. **NEVER** modify validation workflows without understanding impact on PR checks
+8. **NEVER** push directly to `stable`; promote tested `main` commits via the promotion PR from `promote-main-to-stable.yml`
+9. **ALWAYS** test the `:stable-testing` image before merging a promotion to `stable`
+10. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
+11. **ALWAYS** run shellcheck/YAML validation before committing
+12. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`
+13. **ALWAYS** validate that new Flatpak IDs exist on Flathub before adding
+14. **NEVER** modify validation workflows without understanding impact on PR checks
 
 ## Analysis vs Implementation
 


### PR DESCRIPTION
## Summary

Implements projectbluefin/finpilot#57 using the factory promotion contract selected by the arbitration in #235 and #237.

- `main` publishes `:stable-testing` candidates; `stable` publishes `:stable` production images.
- Adds branch-aware build tagging, PR/merge-queue triggers, and publishing on both branches.
- Adds thin callers for the SHA-pinned factory promotion and stable-to-main sync reusable workflows.
- Documents setup, promotion, deployment, branch strategy, and image tags.

The external `pull[bot]` configuration is intentionally not added because the repository arbitration selected `projectbluefin/actions` reusable workflows.

## Validation

- PyYAML parsed every `.github/workflows/*.yml` successfully.
- `just check` passed.
- `just --list` passed.
- `git diff --check` passed.
- Branch-tag simulation produced `main -> DEFAULT_TAG=stable-testing, TAG_STREAM=testing` and `stable -> DEFAULT_TAG=stable, TAG_STREAM=stable`.
- GitHub PR checks passed on the fork branch: PR Validation, Build and Push Image, Validate Brewfiles, Validate Flatpaks, Validate Justfiles, and Validate Renovate Config.
- `actionlint`, `shellcheck`, `pre-commit`, and `hadolint` were not installed in the assigned runtime, so those checks could not be run locally.

Assisted-by: Kimi K3 via Goose

Closes #57
