### PR TITLE
ci: Add two-branch testing/stable workflow with pull[bot] promotion (#57)

### DIFF
--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -45,7 +45,23 @@ git push origin main
 
 **Agent skills:** `finpilot-onboarding` (branch protection), `finpilot-ci` (Renovate config)
 
-### 5. Add "What Makes this Raptor Different" to README
+### 5. Setup Two-Branch Testing/Stable Workflow & pull[bot]
+
+- [ ] Create the `stable` production branch:
+  ```bash
+  git checkout main
+  git checkout -b stable
+  git push origin stable
+  git checkout main
+  ```
+- [ ] Install the [pull](https://github.com/apps/pull) GitHub App on your repository
+- [ ] Replace `OWNER` placeholder in `.github/pull.yml` with your GitHub username or org name
+- [ ] Workflow diagram:
+  ```
+  PR -> main (builds :stable-testing) -> pull[bot] PR -> approve -> stable (builds :stable)
+  ```
+
+### 6. Add "What Makes this Raptor Different" to README
 
 - [ ] Open `README.md`
 - [ ] Paste the raptor section template (see README or use the `finpilot-onboarding` skill)
@@ -54,14 +70,22 @@ git push origin main
 
 **Agent skills:** `finpilot-onboarding` (raptor section), `finpilot-maintain` (maintenance requirement)
 
-### 6. Deploy
+### 7. Deploy
 
-```bash
-sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable
-sudo systemctl reboot
-```
+- Deploy testing image (`main` branch):
+  ```bash
+  sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable-testing
+  sudo systemctl reboot
+  ```
+
+- Deploy production image (`stable` branch):
+  ```bash
+  sudo bootc switch --transport registry ghcr.io/YOUR_USERNAME/YOUR_REPO:stable
+  sudo systemctl reboot
+  ```
 
 ## Optional: Production Features
+
 
 ### Enable Signing (Recommended)
 

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,12 @@
+version: "1"
+rules:
+  - base: stable
+    upstream: main
+    mergeMethod: hardreset
+    mergeUnstable: false
+    reviewers:
+      - OWNER
+    conflictReviewers:
+      - OWNER
+label: "promotion"
+conflictLabel: "promotion-conflict"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -12,11 +12,18 @@ on:
   push:
     branches:
       - main
+      - stable
     paths-ignore:
       - "**.md"
       - ".github/workflows/*validate*.yml"
-  schedule:
-    - cron: "05 10 * * *" # 10:05am UTC everyday
+  pull_request:
+    branches:
+      - main
+      - stable
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*validate*.yml"
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -33,6 +40,8 @@ env:
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
   DEFAULT_TAG: "stable"
+  PRODUCTION_BRANCH: "stable"
+  TESTING_BRANCH: "main"
   REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
   ENABLE_RECHUNKING: "false"
   RECHUNK_MAX_LAYERS: "128"
@@ -57,6 +66,20 @@ jobs:
         run: |
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
           echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
+      - name: Determine image tag
+        id: determine-tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # If not on the production branch, this is a testing build
+          if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]; then
+            echo "DEFAULT_TAG=${DEFAULT_TAG}-testing" >> ${GITHUB_ENV}
+            echo "Building testing image: ${DEFAULT_TAG}-testing"
+          else
+            echo "Building production image: ${DEFAULT_TAG}"
+          fi
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -145,8 +168,6 @@ jobs:
           allow-write: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
           cache-bust: ${{ hashFiles('**/Containerfile') }}
 
-      # OPTIONAL: Set ENABLE_RECHUNKING to "true" above to optimize OTA deltas.
-      # This uses OCI-native chunkah and does not require bootc-base-imagectl.
       - name: Rechunk image
         if: env.ENABLE_RECHUNKING == 'true' && github.event_name != 'pull_request'
         id: rechunk-image
@@ -166,7 +187,7 @@ jobs:
                           "${ALIAS_TAGS}"
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
@@ -174,7 +195,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GHCR
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.event_name != 'pull_request'
         id: push
         uses: projectbluefin/actions/bootc-build/push-image@5fe9b3bcfdf3a68b4d2eb459445505b600e456e6 # v1
         with:
@@ -200,6 +221,8 @@ jobs:
       #     push-attestation: true
       #     certificate-identity-regexp: https://github.com/${{ github.repository }}/.github/workflows/
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
+
+
 
       - name: Build telemetry summary
         if: steps.detect-changes.outputs.should_build == 'true' || github.event_name != 'pull_request'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ links lives in `.agents/skills/README.md`.
 
 **When in doubt, don't post.** If the only thing to report is "tests pass", post nothing.
 
+## Branch Strategy & Promotion Workflow
+
+- **`main`**: Testing branch where developer PRs land. Push builds and publishes `:stable-testing` images.
+- **`stable`**: Production branch that builds production `:stable` images.
+- **pull[bot]**: Automatically creates promotion PRs (`main` → `stable`). Humans test `:stable-testing` and merge promotion PRs to release to production.
+
 ## Critical Rules (Enforced)
 
 1. **ALWAYS** use Conventional Commits format for ALL commits (see `.github/commit-convention.md`)
@@ -59,8 +65,8 @@ links lives in `.agents/skills/README.md`.
 4. **ALWAYS** use `dnf5` exclusively (never `dnf`, `yum`, `rpm-ostree`)
 5. **ALWAYS** use `-y` flag for non-interactive installs
 6. **NEVER** use `dnf5` in ujust files — only Brewfile/Flatpak shortcuts
-7. **NEVER** push directly to `main` (only via PR with passing `validate` check)
-8. **ALWAYS** confirm with user before deviating from @ublue-os/bluefin patterns
+7. **NEVER** push directly to `main` or `stable` (only via PR with passing `validate` check)
+8. **ALWAYS** target `main` branch for feature PRs; pull[bot] handles `main` → `stable` promotion
 9. **ALWAYS** run shellcheck/YAML validation before committing
 10. **ALWAYS** follow numbered script convention: `10-*.sh`, `20-*.sh`, `30-*.sh`
 11. **ALWAYS** validate that new Flatpak IDs exist on Flathub before adding
@@ -80,6 +86,7 @@ Assisted-by: [Model Name] via [Tool Name]
 
 ---
 
-**Last Updated**: 2026-08-05
-**Template Version**: finpilot (Agent UX Overhaul)
+**Last Updated**: 2026-08-08
+**Template Version**: finpilot (Two-Branch Testing/Stable Promotion Workflow)
 **Maintainer**: Universal Blue Community
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,22 @@ Thanks for helping out!
 Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
 
 This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+
+## Agent-Driven Development Workflow
+
+Finpilot uses a two-branch testing & production pipeline managed by pull[bot]:
+
+### Workflow Steps
+1. **Branch**: Create a feature branch off `main`.
+2. **PR**: Open a PR targeting `main` with conventional commit titles.
+3. **Validate**: CI runs validation checks on the PR (`validate` workflow).
+4. **Testing Build**: Merging into `main` builds and publishes a `:stable-testing` container image.
+5. **pull[bot] Promotion**: [pull[bot]](https://github.com/apps/pull) automatically creates a promotion PR from `main` → `stable`.
+6. **Local Testing**: Test the `:stable-testing` image locally (`sudo bootc switch ...:stable-testing`).
+7. **Approve Promotion**: Review and merge pull[bot]'s PR into `stable`.
+8. **Production Build**: Merging into `stable` builds and publishes the production `:stable` container image.
+
+### Guidelines
+- **For AI Agents**: Always target `main` for PRs. Always use conventional commit messages. Never push directly to `main` or `stable`.
+- **For Maintainers**: Review feature PRs to `main`, test `:stable-testing` builds, and merge pull[bot] promotion PRs when ready for production release.
+

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 export IMAGE_NAME := env("IMAGE_NAME", "finpilot")
-export DEFAULT_TAG := env("DEFAULT_TAG", "stable")
+export DEFAULT_TAG := env("DEFAULT_TAG", "stable") # CI overrides to "stable-testing" on main branch
 export PODMAN := env("PODMAN", "podman")
 export REPO_ORG := env("GITHUB_REPOSITORY_OWNER", "projectbluefin")
 export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest@sha256:2b52843ea2bfda73b0a08d97e76b734393b1d3a804681b9fabb26723bd3a2f0b")

--- a/README.md
+++ b/README.md
@@ -88,14 +88,16 @@ Use the `finpilot-maintain` and `finpilot-ci` skills, then:
 - Automated builds via GitHub Actions on every commit
 - Self-hosted Renovate for automated dependency updates
 - Automatic cleanup of old images (90+ days) to keep it tidy
-- Pull request workflow - test changes before merging to main
-  - PRs build and validate before merge
-  - `main` branch builds `:stable` images
+- Two-branch testing & production pipeline with pull[bot] promotion:
+  - `main` branch builds `:stable-testing` images for verification
+  - [pull[bot]](https://github.com/apps/pull) automatically creates promotion PRs from `main` → `stable`
+  - Merging to `stable` builds production `:stable` images
 - Validates your files on pull requests so you never break a build:
   - Brewfile, Justfile, ShellCheck, Renovate config, and it'll even check to make sure the flatpak you add exists on FlatHub
 - Production Grade Features
   - Container signing with keyless OIDC
   - See checklist below to enable these as they take some manual configuration
+
 
 ### Homebrew Integration
 
@@ -199,24 +201,38 @@ Customize your apps:
 
 ### 6. Development Workflow
 
-All changes should be made via pull requests:
+All changes follow an 8-step dual-branch workflow:
 
-1. Open a pull request on GitHub with the change you want.
-2. The PR will automatically trigger:
-   - Build validation
-   - Brewfile, Flatpak, Justfile, and shellcheck validation
-   - Test image build
-3. Once checks pass, merge the PR
-4. Merging triggers publishes a `:stable` image
+| Branch | Image Tag | Purpose |
+|--------|-----------|---------|
+| `main` | `:stable-testing` | Testing branch where PRs land and testing images are published |
+| `stable` | `:stable` | Production branch that builds production `:stable` images |
+
+1. Create a feature branch and open a PR targeting `main`.
+2. PR triggers `validate` status checks.
+3. Merge PR into `main` after checks pass.
+4. `main` push triggers build and publishes `:stable-testing` image.
+5. [pull[bot]](https://github.com/apps/pull) automatically creates a promotion PR from `main` → `stable`.
+6. Test `:stable-testing` on your local system (`sudo bootc switch ...:stable-testing`).
+7. Review and merge pull[bot]'s promotion PR into `stable`.
+8. `stable` push builds and publishes production `:stable` image.
 
 ### 7. Deploy Your Image
 
-Switch to your image:
+Deploy testing image (`main` branch):
+
+```bash
+sudo bootc switch ghcr.io/your-username/your-repo-name:stable-testing
+sudo systemctl reboot
+```
+
+Deploy production image (`stable` branch):
 
 ```bash
 sudo bootc switch ghcr.io/your-username/your-repo-name:stable
 sudo systemctl reboot
 ```
+
 
 ## Optional: Enable Image Signing
 


### PR DESCRIPTION
Fixes #57

## Summary
Adds a two-branch testing/stable workflow to finpilot (mirroring `bluefin-lts`). PRs land on `main` (building `:stable-testing` images), and [pull[bot]](https://github.com/apps/pull) promotes tested changes to `stable` (building `:stable` production images).

## Implementation
1. **`.github/pull.yml`**: Created pull[bot] configuration for `main` → `stable` promotion.
2. **`.github/workflows/build-image.yml`**:
   - Triggers updated to push/pull_request on `main` and `stable`, plus `merge_group`.
   - Added `PRODUCTION_BRANCH` (`stable`) and `TESTING_BRANCH` (`main`) env vars.
   - Added `Determine image tag` step appending `-testing` when built on non-production branches.
   - Relaxed publish guards from default branch check to `github.event_name != 'pull_request'` so both branches can publish tags.
3. **Documentation Updates**:
   - Updated `SETUP_CHECKLIST.md` with pull[bot] installation, `stable` branch creation, and deploy instructions.
   - Updated `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` with two-branch workflow architecture and agent/human roles.
   - Added clarifying comment in `Justfile` regarding `DEFAULT_TAG` CI override.