### PR TITLE
fix(containerfile): break dnf.conf hardlink before config-manager setopt

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -77,7 +77,9 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/build/00-image-info.sh
 
 # Set dnf options before build scripts (persists across subsequent RUN layers)
-RUN dnf5 config-manager setopt keepcache=1 install_weak_deps=0
+RUN cp /etc/dnf/dnf.conf /etc/dnf/dnf.conf.tmp \
+    && mv /etc/dnf/dnf.conf.tmp /etc/dnf/dnf.conf \
+    && dnf5 config-manager setopt keepcache=1 install_weak_deps=0
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache/libdnf5 \


### PR DESCRIPTION
## Problem

Since the `bluefin-dx:stable` rebuild on Aug 13 2026, downstream builds fail on the first `dnf5` command with:

```
Error in configuration file "/etc/dnf/dnf.conf" Missing '=' on line 5
```

## Root cause

The base image ships `/etc/dnf/dnf.conf` as a **hardlink into the ostree object store** (`/sysroot/ostree/repo/objects/...`, `links=2`). The template's STEP rewrites that file **in-place** via `dnf5 config-manager setopt`. Under the GitHub runner's buildah + btrfs storage backend, writing the hardlinked inode corrupts the file: the original content is retained but NUL bytes are appended and the new options are never applied (verified by extracting the cached CI layer: 75 valid bytes + 20 NULs). dnf5 can no longer parse the file.

Locally on fuse-overlayfs the same command succeeds, confirming this is specific to buildah/btrfs hardlink write handling.

## Fix

Break the hardlink before modifying — copy to a temp file then `mv` (fresh inode), then run `config-manager setopt`. Verified end-to-end in `ghcr.io/ublue-os/bluefin-dx:stable`: `links 2 -> 1`, `keepcache=1`/`install_weak_deps=0` written to a clean config, subsequent `dnf5 install` runs without the parser error.

## Notes

- A drop-in under `/etc/dnf/dnf.conf.d/` is **not** a viable alternative: dnf5 reads the main config last, so `keepcache=0` in the main file would override the drop-in.
- The corrupted cached layer from failed builds is automatically invalidated because the STEP content (and therefore the cache key) changes.

Assisted-by: big-pickle via opencode