### PR TITLE
fix(ci): grant packages:read to promotion reusable caller

### DIFF
--- a/.agents/skills/finpilot-ci/SKILL.md
+++ b/.agents/skills/finpilot-ci/SKILL.md
@@ -70,6 +70,15 @@ uses: projectbluefin/actions/bootc-build/setup-runner@<sha> # v1
 
 The SHA comment (`# v1`) is for human readability only — Renovate ignores it.
 
+## Reusable Workflow Permissions
+
+A caller's `permissions:` block is a **ceiling** for every nested job in a reusable
+workflow. A nested job requesting an ungranted permission fails the whole workflow
+at startup (`startup_failure`, no jobs run, no logs — only the inline validation
+error). Issue #256: `promote-main-to-stable.yml` omitted `packages`, but the
+reusable's `gate` job requests `packages: read`. Fix: union every nested job's
+permissions into the caller.
+
 ## Rechunking
 
 Set `ENABLE_RECHUNKING: "true"` in `build-image.yml` to enable the existing

--- a/.agents/skills/finpilot-ci/SKILL.md
+++ b/.agents/skills/finpilot-ci/SKILL.md
@@ -76,8 +76,8 @@ A caller's `permissions:` block is a **ceiling** for every nested job in a reusa
 workflow. A nested job requesting an ungranted permission fails the whole workflow
 at startup (`startup_failure`, no jobs run, no logs — only the inline validation
 error). Issue #256: `promote-main-to-stable.yml` omitted `packages`, but the
-reusable's `gate` job requests `packages: read`. Fix: union every nested job's
-permissions into the caller.
+reusable's `gate` job requests `packages: read`. Fix: update the caller to grant
+at least the permission(s) requested by the reusable workflow (prefer the minimal set).
 
 ## Rechunking
 

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -18,10 +18,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
   actions: read
+  contents: write
+  issues: write
+  packages: read
+  pull-requests: write
   statuses: write
 
 concurrency:


### PR DESCRIPTION
## Summary

Fixes the startup failure in the **Promote main to stable** workflow (issue #256). Every run of this workflow has failed at startup since it was introduced — the caller's `permissions:` block omits `packages`, but the nested `gate` job in `projectbluefin/actions/.github/workflows/reusable-promote-squash.yml` requests `packages: read`. A caller's permissions are a ceiling for nested jobs, so GitHub rejects the whole workflow:

> Error calling workflow '...reusable-promote-squash.yml@8906e13'. The nested job 'gate' is requesting 'packages: read', but is only allowed 'packages: none'.

## Changes

- `.github/workflows/promote-main-to-stable.yml`: add `packages: read` to workflow permissions (and sort alphabetically)
- `.agents/skills/finpilot-ci/SKILL.md`: record the reusable-workflow permission gotcha

## Validation

- YAML parses clean; `actionlint` passes on the modified workflow
- Re-ran the Promote workflow on this branch — it now starts (first time ever) and completes successfully with the expected initial-state notice: "main and stable are identical — nothing to promote"

## Repo state (already done, not part of this PR)

The `stable` branch did not exist on this repo (issue #57 Task 8 was never executed), which made the Promote job fail with `fatal: couldn't find remote ref stable` after the permission fix. It has been created from current `main` (`8cc2dc9`), per issue #57's spec. Once this PR merges to `main`, the push-triggered Promote run will compare identical trees and go green until `main` advances.

Closes #256