### PR TITLE
fix(ci): enable native overlay for faster layer commits

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -98,6 +98,7 @@ jobs:
         uses: projectbluefin/actions/bootc-build/setup-runner@cad7d15c30224a7a1a49c5ff0fd2054ca57b9cfd # v1
         with:
           storage-backend: btrfs
+          native-overlay: "true"
           update-podman: "true"
           install-tools: '["just"]'
 


### PR DESCRIPTION
Enables kernel overlayfs via \`native-overlay: true\` in \`bootc-build/setup-runner@cad7d15\`.

**Why:** On runner images \`20260810.271.1+\` (\`HCA 20260729.566\`, \`6.17.0-1022-azure\`) \`fuse-overlayfs\` with \`Native Overlay Diff=false\` naively walks 257 silverblue ostree layers per RUN. Logs show \`Wrote→Pushing cache\` inflated \`128s→1479s\` (\`00-image-info\`), \`142→1751s\` (\`dnf config\`), \`100→1682s\` (\`10-build\`), \`92→1671s\` (\`clean-stage\`) — +6114s (99% of +6162s) hitting \`timeout_minutes: 120\` (\`31703857881 15m43s\` vs \`31892745630 2h02m\`). Only \`Containerfile:54\` digest changed (\`2ab305→1d1810\`), pin \`8906e13\` identical — host regression, not code.

**What:** \`setup-runner\` now does \`podman system reset\` + \`/etc/containers/storage.conf\` \`driver=overlay mountopt=nodev\` (no \`mount_program\`). Keeps \`storage-backend: btrfs\` + \`update-podman: true\` (\`5.7.0\`). Expected \`~2m/RUN\` as in success, back under 120m.

* Diff of runs & timing in /tmp/opencode/\`diff-317-vs-318.md\` / \`timing-317-vs-318.md\` / \`why-10x.md\` (subagents).

Closes timeout flake from #253 onwards.