### PR TITLE
feat(ci): enable keyless image signing by default

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -13,7 +13,7 @@ file whose frontmatter tells compatible agents when to load it.
 | [`finpilot-router`](finpilot-router/SKILL.md) | The task routing table: which skill covers what, and the standard sequence. Load when unsure. |
 | [`finpilot-overview`](finpilot-overview/SKILL.md) | Repository architecture and file layout. Start here for orientation. |
 | [`finpilot-onboarding`](finpilot-onboarding/SKILL.md) | Bootstrap a new fork: rename, enable Actions, first green build, raptor section, branch protection. |
-| [`finpilot-templates`](finpilot-templates/SKILL.md) | The 7 rename locations, image identity ARGs, signing setup, AGENTS.md update rules. |
+| [`finpilot-templates`](finpilot-templates/SKILL.md) | The 7 rename locations, image identity ARGs, signing verification, AGENTS.md update rules. |
 | [`finpilot-packages`](finpilot-packages/SKILL.md) | Decision tree: where to add packages (dnf5, Brew, Flatpak). |
 | [`finpilot-custom`](finpilot-custom/SKILL.md) | Runtime layer: Brewfiles, Flatpaks, ujust, and validation. |
 | [`finpilot-build`](finpilot-build/SKILL.md) | Containerfile, Justfile, build scripts, image pinning, advanced topics. |

--- a/.agents/skills/finpilot-ci/SKILL.md
+++ b/.agents/skills/finpilot-ci/SKILL.md
@@ -55,8 +55,9 @@ description: >-
 - The `Determine image tag` step sets `TAG_STREAM=testing` off the production
   branch; `Finalize branch tags` renames `testing*` tags to `stable-testing-*`
   so they never collide with production `stable-daily*` aliases.
-- The release gate verifies cosign signatures on `:testing`; keyless signing
-  (optional step in `build-image.yml`) must be enabled for `release/ready`.
+- The release gate verifies cosign signatures on `:testing`; the `Sign and
+  publish` step in `build-image.yml` provides them, and unsigned images report
+  `release/blocked`.
 
 ## Composite Action Pins
 

--- a/.agents/skills/finpilot-maintain/SKILL.md
+++ b/.agents/skills/finpilot-maintain/SKILL.md
@@ -2,7 +2,7 @@
 name: finpilot-maintain
 description: >-
   Maintenance of an active finpilot fork: Renovate digest PRs, README raptor
-  section updates, signing enablement, local test loops, and maintenance
+  section updates, signing verification, local test loops, and maintenance
   schedules. Use when maintaining a fork after onboarding.
 ---
 
@@ -12,7 +12,7 @@ description: >-
 
 - Reviewing and merging Renovate PRs for OCI digest bumps
 - Updating the README "What Makes this Raptor Different" section after changes
-- Deciding whether to enable image signing for production
+- Verifying image signing works for production
 - Running local test builds before pushing changes
 - Planning a maintenance schedule for your fork
 
@@ -28,7 +28,7 @@ description: >-
 2. **Update README raptor section** whenever packages or configuration change
 3. **Run local test loop** before opening PRs
 4. **Open PRs to `main`** — never push directly
-5. **Enable signing** when ready for production
+5. **Verify signing** works after the first signed build
 
 ## Handle Renovate Digest PRs
 
@@ -75,12 +75,11 @@ _Last updated: [date]_
 Always update the date. Keep descriptions brief and user-focused, written for
 typical Linux users, not developers.
 
-## Enable Signing When Ready for Production
+## Verify Signing
 
-Signing is **disabled by default** to allow first builds to succeed. Enable when
-your fork is stable: uncomment the `Sign and publish` step in
-`.github/workflows/build-image.yml` — full setup and verification:
-`finpilot-templates`.
+Keyless OIDC signing runs via the `Sign and publish` step in
+`.github/workflows/build-image.yml`. Unsigned images fail the promotion release
+gate, so leave it enabled. Full details: `finpilot-templates`.
 
 ## Local Test Loop
 
@@ -160,7 +159,7 @@ digest-only PRs. If Renovate stops creating PRs, run the Renovate section of
 
 - Review and clean up old branches
 - Verify `RENOVATE_TOKEN` still valid
-- Consider enabling signing if not already enabled
+- Verify signing works (`cosign verify` on the latest `:stable` image)
 - Review `build/*.sh` scripts for obsolete packages or patterns
 
 ### Annually
@@ -178,7 +177,7 @@ digest-only PRs. If Renovate stops creating PRs, run the Renovate section of
 | "I'll update the README later when I have more changes."                    | Update incrementally. "Later" often means never, and users rely on README for current state.        |
 | "Local builds are optional since CI builds everything."                     | Local builds catch issues faster and don't burn CI minutes. The `just build` loop is essential.     |
 | "I'll push to main to save time."                                           | PRs are cheap. Direct pushes bypass validation and create untraceable changes.                      |
-| "Signing is too hard — I'll skip it."                                       | Keyless OIDC signing is one uncomment step. The hard part is already done in the workflow template. |
+| "Signing is too hard — I'll skip it."                                       | Keyless OIDC signing is already enabled in the template — no setup, no secrets.                     |
 
 ## Red Flags
 
@@ -186,7 +185,7 @@ digest-only PRs. If Renovate stops creating PRs, run the Renovate section of
 - README raptor section missing or severely outdated
 - No local builds run before PRs are opened
 - Direct pushes to `main` bypassing branch protection
-- Signing still disabled after months of production use
+- Signing step removed or disabled (promotion gate will block releases)
 - `RENOVATE_TOKEN` expired (Renovate workflow fails)
 
 ## Verification
@@ -195,5 +194,5 @@ digest-only PRs. If Renovate stops creating PRs, run the Renovate section of
 - [ ] Is the README raptor section updated for the latest changes?
 - [ ] Was `just build` run locally before the last PR?
 - [ ] Are all pushes to `main` via PR with passing `validate` check?
-- [ ] Is image signing enabled (or on the roadmap for production)?
+- [ ] Is image signing verified working?
 - [ ] Is `RENOVATE_TOKEN` valid and the Renovate workflow running?

--- a/.agents/skills/finpilot-onboarding/SKILL.md
+++ b/.agents/skills/finpilot-onboarding/SKILL.md
@@ -31,7 +31,7 @@ description: >-
 5. **Configure branch protection and auto-merge**
 6. **Trigger first build**
 7. **Add the "What Makes this Raptor Different" section to README** (template below)
-8. **Enable signing** (optional, recommended for production; setup: `finpilot-templates`)
+8. **Verify signing** on the first signed build (`finpilot-templates`)
 
 Keep day-one changes minimal and iterate in phases:
 
@@ -41,7 +41,7 @@ Keep day-one changes minimal and iterate in phases:
    (`finpilot-packages`, `finpilot-build`)
 3. **Phase 3 — Runtime**: add Flatpak/Brew customizations, test in a VM with
    `just run-vm-qcow2` (`finpilot-custom`)
-4. **Phase 4 — Production**: enable signing, full branch protection
+4. **Phase 4 — Production**: verify signing, full branch protection
    (`finpilot-templates`, `finpilot-maintain`)
 
 Resist changing everything at once — each phase validates the previous.
@@ -129,10 +129,9 @@ _Last updated: [date]_
 **Maintenance requirement**: update this section on every package or
 configuration change — see the update rules in `finpilot-maintain`.
 
-## Optional Signing Setup
+## Signing
 
-Signing is **disabled by default** so first builds succeed immediately. Enable
-later for production — full keyless OIDC setup and verification:
+No setup required — first builds publish signed images. Verification details:
 `finpilot-templates`.
 
 ## Common Rationalizations
@@ -142,7 +141,7 @@ later for production — full keyless OIDC setup and verification:
 | "I'll rename the obvious places and fix the rest later."       | Missing `.github/workflows/clean.yml` or `iso/iso.toml` causes silent failures months later. Do all 7 now. |
 | "I don't need branch protection for a personal fork."          | Without it, Renovate auto-merge won't work, and digest PRs sit unmerged.                                   |
 | "I'll add the raptor section to README after I have packages." | Add the section immediately with placeholders. Update it iteratively.                                      |
-| "Signing is too much work for a first build."                  | Signing is disabled by default. First builds succeed immediately. Enable later.                            |
+| "Signing is too much work for a first build."                  | Nothing to configure — builds sign images automatically.                                                   |
 | "I'll use my fine-grained PAT for Renovate."                   | Renovate requires a **Classic PAT** with `repo` + `workflow` scopes. Fine-grained PATs do not work.        |
 
 ## Red Flags
@@ -163,4 +162,4 @@ later for production — full keyless OIDC setup and verification:
 - [ ] Branch protection for `main` configured with `validate` as required check?
 - [ ] First green build succeeded and image published to GHCR?
 - [ ] README contains the "What Makes this Raptor Different" section?
-- [ ] Optional signing enabled (or deferred for later)?
+- [ ] Signing verified on the first signed build?

--- a/.agents/skills/finpilot-templates/SKILL.md
+++ b/.agents/skills/finpilot-templates/SKILL.md
@@ -2,8 +2,8 @@
 name: finpilot-templates
 description: >-
   Template identity rules: the seven rename locations, image identity ARGs,
-  keyless signing setup, and AGENTS.md update rules. Use when renaming a fork,
-  enabling signing, or updating AGENTS.md and setup docs.
+  keyless signing, and AGENTS.md update rules. Use when renaming a fork,
+  verifying or explaining signing, or updating AGENTS.md and setup docs.
 metadata:
   context7-sources:
     - /renovatebot/renovate
@@ -14,7 +14,7 @@ metadata:
 ## When to Use
 
 - Renaming `finpilot` in a fork (the 7 locations)
-- Enabling or explaining keyless signing
+- Verifying or explaining keyless signing
 - Updating AGENTS.md or copilot instructions
 - Updating README.md setup sections or SETUP_CHECKLIST.md
 - Documenting new mandatory setup steps for forks
@@ -29,7 +29,7 @@ metadata:
 
 1. **Rename in the 7 locations** (table below)
 2. **Check the image identity ARGs** match the new name (below)
-3. **Enable keyless signing** when the fork is production-ready (below)
+3. **Verify keyless signing** works on the fork's first signed build (below)
 4. **Update AGENTS.md** per the rules below
 5. **Verify** against the checklist at the end of this skill
 
@@ -88,16 +88,14 @@ These are consumed by `build/00-image-info.sh` to write:
 - `/usr/share/ublue-os/image-info.json` (read by the ublue ecosystem)
 - `/usr/lib/os-release` branding fields
 
-## Signing Setup (Keyless OIDC)
+## Signing (Keyless OIDC)
 
-This template uses **keyless OIDC signing** via Cosign + Fulcio. No `cosign.key`,
-`cosign.pub`, or `SIGNING_SECRET` are needed.
+Images are signed automatically via **keyless OIDC signing** with Cosign + Fulcio —
+the `Sign and publish` step in `.github/workflows/build-image.yml`. No `cosign.key`,
+`cosign.pub`, or `SIGNING_SECRET` are needed, and no setup is required.
 
-To enable:
-
-1. Edit `.github/workflows/build-image.yml`
-2. Find the `# OPTIONAL: Sign and attest` section
-3. Uncomment the `Sign and publish` step
+Unsigned images fail the promotion release gate (`release/blocked`), so leave the
+step enabled.
 
 Users verify images with:
 
@@ -141,6 +139,6 @@ Static-key signing (`SIGNING_SECRET`) is not supported by this template.
 
 - [ ] All 7 rename locations updated?
 - [ ] `IMAGE_NAME` / `IMAGE_VENDOR` ARGs match the fork?
-- [ ] Signing enabled only via keyless OIDC (no `cosign.key`/`cosign.pub`)?
+- [ ] Signing uses keyless OIDC only (no `cosign.key`/`cosign.pub`)?
 - [ ] `AGENTS.md` uses semantic references (no line numbers)?
 - [ ] `AGENTS.md` `Last Updated` date current?

--- a/.agents/skills/finpilot-troubleshooting/SKILL.md
+++ b/.agents/skills/finpilot-troubleshooting/SKILL.md
@@ -32,17 +32,17 @@ description: >-
 
 ## Local Build Failures
 
-| Symptom                                | Cause                                                                        | Solution                                                                                    |
-| -------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Build fails: "permission denied"       | Signing misconfigured or signing step uncommented without proper permissions | Verify signing step is commented out OR `id-token: write` permission is granted in workflow |
-| Build fails: "package not found"       | Typo in package name, or package unavailable in configured repos             | Check spelling, verify on RPMfusion, add COPR if needed                                     |
-| Build fails: "base image not found"    | Invalid `FROM` line or digest mismatch                                       | Check Containerfile syntax, verify base image tag and digest                                |
-| Build fails: "shellcheck error"        | Script syntax error in `build/*.sh`                                          | Run `shellcheck build/*.sh` locally, fix errors                                             |
-| `bootc container lint` fails           | Missing cleanup, leftover artifacts, or invalid image structure              | Run `build/clean-stage.sh` manually, check for stray files in `/opt` or `/var`              |
-| Podman/Docker not found                | Container runtime not installed                                              | Install `podman` or `docker`, ensure daemon is running                                      |
-| Base image pull fails                  | Network issue or invalid digest                                              | Verify network, check digest is correct, try `podman pull <base-image>` manually            |
-| Multi-stage build fails at `ctx` stage | Missing `COPY --from=` or invalid OCI image reference                        | Verify OCI image names and digests in `Containerfile` ctx stage                             |
-| `just build` fails immediately         | `just` not installed or `Justfile` syntax error                              | Run `just --list`, check `Justfile` for syntax errors                                       |
+| Symptom                                | Cause                                                            | Solution                                                                         |
+| -------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Build fails: "permission denied"       | Signing misconfigured or `id-token: write` permission missing    | Verify `id-token: write` and `attestations: write` are granted in the workflow   |
+| Build fails: "package not found"       | Typo in package name, or package unavailable in configured repos | Check spelling, verify on RPMfusion, add COPR if needed                          |
+| Build fails: "base image not found"    | Invalid `FROM` line or digest mismatch                           | Check Containerfile syntax, verify base image tag and digest                     |
+| Build fails: "shellcheck error"        | Script syntax error in `build/*.sh`                              | Run `shellcheck build/*.sh` locally, fix errors                                  |
+| `bootc container lint` fails           | Missing cleanup, leftover artifacts, or invalid image structure  | Run `build/clean-stage.sh` manually, check for stray files in `/opt` or `/var`   |
+| Podman/Docker not found                | Container runtime not installed                                  | Install `podman` or `docker`, ensure daemon is running                           |
+| Base image pull fails                  | Network issue or invalid digest                                  | Verify network, check digest is correct, try `podman pull <base-image>` manually |
+| Multi-stage build fails at `ctx` stage | Missing `COPY --from=` or invalid OCI image reference            | Verify OCI image names and digests in `Containerfile` ctx stage                  |
+| `just build` fails immediately         | `just` not installed or `Justfile` syntax error                  | Run `just --list`, check `Justfile` for syntax errors                            |
 
 ## NVIDIA-Specific Issues
 
@@ -58,18 +58,19 @@ description: >-
 
 ## CI Failures
 
-| Symptom                                    | Cause                                              | Solution                                                                  |
-| ------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------- |
-| PR validation fails: shellcheck            | Syntax error in modified `.sh` file                | Run `shellcheck build/*.sh` locally, fix errors                           |
-| PR validation fails: hadolint              | Dockerfile lint rule violation                     | Check `.hadolint.yaml` for allowed suppressions, fix or document new ones |
-| PR validation fails: Brewfile              | Invalid Brewfile syntax                            | Check Ruby syntax, ensure packages exist (`brew search`)                  |
-| PR validation fails: Flatpak               | Invalid app ID                                     | Verify app ID exists on https://flathub.org/                              |
-| PR validation fails: justfile              | Invalid just syntax                                | Run `just --list` locally to test, fix syntax                             |
-| CI build fails: workflow permissions       | Missing `id-token: write` or `packages: write`     | Verify `.github/workflows/build-image.yml` has correct permissions        |
-| CI build fails: token health               | `RENOVATE_TOKEN` or `GITHUB_TOKEN` invalid/expired | Check token expiry, verify scopes, regenerate if needed                   |
-| CI build fails: signing misconfig          | Signing step uncommented but OIDC not configured   | Comment out signing step OR verify OIDC trust in repo settings            |
-| CI build fails: composite action not found | Wrong commit SHA or repo name in `uses:`           | Verify `projectbluefin/actions` SHA, check network access                 |
-| CI build succeeds but image not published  | Wrong `IMAGE_NAME` or `IMAGE_VENDOR`               | Check `Containerfile` ARGs, verify `clean.yml` package name matches       |
+| Symptom                                                                 | Cause                                                                                                                                       | Solution                                                                                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| PR validation fails: shellcheck                                         | Syntax error in modified `.sh` file                                                                                                         | Run `shellcheck build/*.sh` locally, fix errors                                                                           |
+| PR validation fails: hadolint                                           | Dockerfile lint rule violation                                                                                                              | Check `.hadolint.yaml` for allowed suppressions, fix or document new ones                                                 |
+| PR validation fails: Brewfile                                           | Invalid Brewfile syntax                                                                                                                     | Check Ruby syntax, ensure packages exist (`brew search`)                                                                  |
+| PR validation fails: Flatpak                                            | Invalid app ID                                                                                                                              | Verify app ID exists on https://flathub.org/                                                                              |
+| PR validation fails: justfile                                           | Invalid just syntax                                                                                                                         | Run `just --list` locally to test, fix syntax                                                                             |
+| CI build fails: workflow permissions                                    | Missing `id-token: write` or `packages: write`                                                                                              | Verify `.github/workflows/build-image.yml` has correct permissions                                                        |
+| CI build fails: token health                                            | `RENOVATE_TOKEN` or `GITHUB_TOKEN` invalid/expired                                                                                          | Check token expiry, verify scopes, regenerate if needed                                                                   |
+| CI build fails: signing misconfig                                       | OIDC token unavailable (self-hosted runner or restricted permissions)                                                                       | Verify `id-token: write` is granted and the runner supports OIDC; signing is `continue-on-error`, so builds still publish |
+| CI build fails: composite action not found                              | Wrong commit SHA or repo name in `uses:`                                                                                                    | Verify `projectbluefin/actions` SHA, check network access                                                                 |
+| CI build succeeds but image not published                               | Wrong `IMAGE_NAME` or `IMAGE_VENDOR`                                                                                                        | Check `Containerfile` ARGs, verify `clean.yml` package name matches                                                       |
+| Promotion gate blocked: `release/blocked`, cosign "no signatures found" | Image pushed by an older template snapshot before signing was default, or the `Sign and publish` step failed silently (`continue-on-error`) | Merge a new build on `main` so a signed `:testing` image is published; check the build log's sign step for errors         |
 
 ## Runtime Issues
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -250,23 +250,24 @@ jobs:
           default-tag: ${{ steps.branch-tags.outputs.default-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # OPTIONAL: Sign and attest (SLSA Build L2 provenance)
+      # Sign and attest (SLSA Build L2 provenance)
       # Bluefin pattern: keyless OIDC signing via Fulcio.
-      # Uncomment to enable. Requires 'id-token: write' permission (already granted).
-      # Non-fatal — signing failures never block image publishing.
+      # Requires 'id-token: write' permission (granted above).
+      # Non-fatal — signing failures never block image publishing,
+      # but unsigned images fail the promotion release gate.
 
-      # - name: Sign and publish
-      #   if: github.event_name != 'pull_request'
-      #   continue-on-error: true
-      #   uses: projectbluefin/actions/bootc-build/sign-and-publish@6231015b336556d2ff0adc1d1e59514bf19dcb42 # v1
-      #   with:
-      #     image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-      #     digest: ${{ steps.push.outputs.digest }}
-      #     signing-mode: keyless
-      #     generate-sbom: false
-      #     push-attestation: true
-      #     certificate-identity-regexp: https://github.com/${{ github.repository }}/.github/workflows/
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sign and publish
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: projectbluefin/actions/bootc-build/sign-and-publish@eb4c546389f19ad9e42f1af052623de73c620ebb # v1
+        with:
+          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          digest: ${{ steps.push.outputs.digest }}
+          signing-mode: keyless
+          generate-sbom: false
+          push-attestation: true
+          certificate-identity-regexp: https://github.com/${{ github.repository }}/.github/workflows/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build telemetry summary
         if: steps.detect-changes.outputs.should_build == 'true' || github.event_name != 'pull_request'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ links lives in `.agents/skills/README.md`.
 | `stable` | `:stable`         | Production systems             |
 
 The promotion release gate verifies cosign signatures on the `:testing` tag;
-enable keyless signing (SETUP_CHECKLIST "Enable Signing") for it to report
-`release/ready`.
+keyless signing is enabled by default in `build-image.yml` ("Sign and publish"
+step) and reports `release/ready` once a signed `:testing` image exists.
 
 ## CRITICAL: GitHub API Usage
 
@@ -138,6 +138,6 @@ Before marking work done:
 - [ ] Updated or created the relevant skill file?
 - [ ] Included that learning in this PR?
 
-**Last Updated**: 2026-08-05
+**Last Updated**: 2026-08-21
 **Template Version**: finpilot (Agent UX Overhaul)
 **Maintainer**: Universal Blue Community

--- a/README.md
+++ b/README.md
@@ -76,9 +76,8 @@ When you are ready for production, use this prompt to harden the setup:
 
 ```
 Use the `finpilot-maintain` and `finpilot-ci` skills, then:
-1. Enable keyless image signing by uncommenting the step in `.github/workflows/build-image.yml`
-2. Verify the cosign command works: cosign verify --certificate-identity-regexp="https://github.com/USER/REPO/.github/workflows/" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" ghcr.io/USER/REPO:stable
-3. Follow the maintenance schedule in the `finpilot-maintain` skill
+1. Verify keyless image signing works: cosign verify --certificate-identity-regexp="https://github.com/USER/REPO/.github/workflows/" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" ghcr.io/USER/REPO:stable
+2. Follow the maintenance schedule in the `finpilot-maintain` skill
 ```
 
 ## What's Included
@@ -95,7 +94,6 @@ Use the `finpilot-maintain` and `finpilot-ci` skills, then:
   - Brewfile, Justfile, ShellCheck, Renovate config, and it'll even check to make sure the flatpak you add exists on FlatHub
 - Production Grade Features
   - Container signing with keyless OIDC
-  - See checklist below to enable these as they take some manual configuration
 
 ### Homebrew Integration
 
@@ -148,7 +146,7 @@ Important: Change `finpilot` to your repository name in these 7 files:
 
 Your first build will start automatically!
 
-Note: Image signing is disabled by default. Your images will build successfully without any signing keys. Once you're ready for production, see "Optional: Enable Image Signing" below.
+Note: Images are signed automatically with keyless OIDC signing — no keys or secrets to configure. See "Image Signing" below for details.
 
 ### 4. Enable Renovate (Required)
 
@@ -238,9 +236,9 @@ sudo bootc switch ghcr.io/your-username/your-repo-name:stable
 sudo systemctl reboot
 ```
 
-## Optional: Enable Image Signing
+## Image Signing
 
-Image signing is disabled by default to let you start building immediately. However, signing is strongly recommended for production use.
+Images are signed automatically with **keyless OIDC signing** via Cosign and GitHub Actions. No manual key generation, `cosign.key`, or `cosign.pub` files are required — the signature is created using GitHub's OIDC token via Fulcio during each build.
 
 ### Why Sign Images?
 
@@ -248,19 +246,9 @@ Image signing is disabled by default to let you start building immediately. Howe
 - Prevent tampering and supply chain attacks
 - Required for some enterprise/security-focused deployments
 - Industry best practice for production images
+- **Required for promotion**: the `main → stable` release gate verifies signatures on `:testing` and blocks promotion of unsigned images
 
-### Setup Instructions
-
-This template uses **keyless OIDC signing** via Cosign and GitHub Actions. No manual key generation, `cosign.key`, or `cosign.pub` files are required.
-
-1. Edit `.github/workflows/build-image.yml`
-2. Find the "OPTIONAL: Sign and attest" section
-3. Uncomment the `Sign and publish` step (remove the `#` from the beginning of each line in that section)
-4. Commit and push
-
-Your next build will produce a signed image. The signature is created using GitHub's OIDC token via Fulcio.
-
-Users can verify your images with:
+### Verify a Signed Image
 
 ```bash
 cosign verify \
@@ -269,18 +257,21 @@ cosign verify \
   ghcr.io/your-username/your-repo-name:stable
 ```
 
+### Disabling Signing (Not Recommended)
+
+To disable, comment out the `Sign and publish` step in `.github/workflows/build-image.yml`. Be aware that unsigned images will fail the promotion release gate, so `main → stable` promotions will report `release/blocked` until signing is re-enabled.
+
 ## Love Your Image? Let's Go to Production
 
 Ready to take your custom OS to production? Enable these features for enhanced security, reliability, and performance:
 
 ### Production Checklist
 
-- [ ] **Enable Image Signing** (Recommended)
+- [ ] **Verify Image Signing**
   - Provides cryptographic verification of your images
   - Prevents tampering and ensures authenticity
   - Uses keyless OIDC signing via GitHub Actions — no keys or secrets required
-  - See "Optional: Enable Image Signing" section above for setup instructions
-  - Status: **Disabled by default** to allow immediate testing
+  - Verify it works with the `cosign verify` command in the "Image Signing" section above
 
 - [ ] **Enable Image Rechunking** (Recommended)
   - Optimizes bootc image layers for better update performance
@@ -395,11 +386,11 @@ just run-vm-qcow2       # Test in browser-based VM
 
 This template provides security features for production use:
 
-- Optional image signing with keyless OIDC cosign for cryptographic verification
+- Image signing with keyless OIDC cosign for cryptographic verification
 - Automated security updates via Renovate
 - Build provenance tracking
 
-These security features are disabled by default to allow immediate testing. When you're ready for production, see the "Love Your Image? Let's Go to Production" section above to enable them.
+Signing and Renovate run automatically; see the "Love Your Image? Let's Go to Production" section above for optional production hardening like rechunking.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

The promotion release gate verifies cosign signatures on the \`:testing\` tag, but the \`Sign and publish\` step in \`build-image.yml\` was commented out — so every published image was unsigned and \`main → stable\` promotions have been permanently blocked (\`release/blocked\`, see #269).

This enables keyless OIDC signing by default and updates all documentation to match.

## Changes

- **\`.github/workflows/build-image.yml\`** — uncomment the \`Sign and publish\` step; re-pin from the stale \`6231015b\` digest to \`eb4c546\` (same as sibling steps) so Renovate tracks it. Step behavior otherwise unchanged: keyless mode, \`continue-on-error\`, skipped on PRs. Required permissions (\`id-token: write\`, \`attestations: write\`) were already granted.
- **README.md** — "Optional: Enable Image Signing" rewritten as an always-on "Image Signing" section (gate linkage, verify command, disable caveat); onboarding notes, feature list, production checklist, and security section updated
- **AGENTS.md** — release-gate paragraph now states signing is default-on instead of instructing enablement; \`Last Updated\` bumped
- **Skills** (\`ci\`, \`maintain\`, \`onboarding\`, \`templates\`, \`troubleshooting\`, index) — enable-instructions replaced with verification guidance; troubleshooting rows that advised commenting out the step now point at permissions/OIDC; new row for the gate-blocked \`no signatures found\` symptom

## Validation

- [x] \`actionlint .github/workflows/build-image.yml\` passes
- [x] YAML parse passes
- [x] cosign verify reproduced the failure locally (\`no signatures found\`) confirming root cause
- [ ] First signed build on \`main\` after merge (publishes signed \`:testing\`; next promotion run should report \`release/ready\`)

Assisted-by: ox-alpha via OpenCode