### PR TITLE
docs: align signing, branch-model, and promotion docs with current behavior

### DIFF
--- a/.agents/skills/finpilot-build/SKILL.md
+++ b/.agents/skills/finpilot-build/SKILL.md
@@ -61,8 +61,8 @@ release, update both the `FEDORA_MAJOR_VERSION` ARG and the base image tag.
 
 ### Template build script rules
 
-- **Default packages**: build scripts in the template must have **no packages installed by default** — only commented examples. Users add their own.
-- **Exception**: `dnf5 install -y tmux` is intentionally present as a minimal smoke-test that the DNF cache is warm. Do not remove it.
+- **Default packages**: build scripts in the template must have **no extra packages installed by default** — only commented examples. Users add their own.
+- **Exception**: `dnf5 install -y tmux gum` in `build/10-build.sh` is intentional: tmux smoke-tests that the DNF cache is warm, and gum is required by the ujust recipes' interactive prompts. Do not remove.
 - Always use `dnf5` — never `dnf`, `yum`, or `rpm-ostree`
 - Always use `dnf5 install -y` (non-interactive)
 - COPR: enable → install → `copr_install_isolated` (auto-disables); never leave a repo enabled

--- a/.agents/skills/finpilot-onboarding/SKILL.md
+++ b/.agents/skills/finpilot-onboarding/SKILL.md
@@ -82,6 +82,25 @@ This token allows Renovate to open PRs for digest bumps and dependency updates.
 
 This ensures PRs are validated before merging and Renovate can auto-merge safe digest updates.
 
+## Set Up Promotion (Stable Branch)
+
+Create `stable` as an exact copy of `main` (git commands in `SETUP_CHECKLIST.md`
+step 3). The `promote-main-to-stable.yml` workflow then automates releases:
+
+1. Pushes to `main` publish `:stable-testing`; a squash PR to `stable` opens
+   automatically whenever the trees differ
+2. The PR requests review from `<owner>/maintainers` — org forks need that
+   team; personal-account forks should replace the caller workflow with a
+   local one that skips reviewer requests
+3. `stable`'s required approvals set the automation level: `0` = fully
+   automatic, `1` = review, then auto-merge
+4. Keyless signing (enabled by default) feeds the release gate — signed
+   `:testing` images report `release/ready`; unsigned images report
+   `release/blocked`
+
+Full requirements live in `SETUP_CHECKLIST.md` → step 3; promotion mechanics
+in `finpilot-ci`.
+
 ## First Green Build
 
 After the rename and secret setup, trigger a build:
@@ -92,7 +111,7 @@ After the rename and secret setup, trigger a build:
 Monitor the workflow. A successful first build:
 
 - Passes `bootc container lint --fatal-warnings`
-- Publishes `:stable` and `:stable.YYYYMMDD` tags to GHCR
+- Publishes `:stable-testing` and `:testing` tags to GHCR (`stable` branch builds publish `:stable`)
 - Appears under **Packages** in your repository
 
 ## README "What Makes this Raptor Different" Section

--- a/.agents/skills/finpilot-pr-checklist/SKILL.md
+++ b/.agents/skills/finpilot-pr-checklist/SKILL.md
@@ -155,6 +155,18 @@ just --list
 
 **CI triggers:** None by default (consider adding `markdownlint` to pre-commit)
 
+### Repo-wide Doc Sweeps
+
+| Check                   | Command                                                              |
+| ----------------------- | -------------------------------------------------------------------- |
+| Include dot-directories | `grep -rn "pattern" .github .agents` (don't rely on `grep -r .` alone) |
+
+`.github/` and `.agents/` hold most of this template's docs, skills, and
+workflows. A recursive search rooted at `.` can silently skip dot-directories
+depending on grep configuration — target them explicitly when auditing docs
+for stale claims, and verify every reported location against the real file
+before editing.
+
 ---
 
 ## PR Status Check Reference

--- a/.agents/skills/finpilot-router/SKILL.md
+++ b/.agents/skills/finpilot-router/SKILL.md
@@ -30,6 +30,7 @@ description: >-
 | I need to…                                     | Load                                      |
 | ---------------------------------------------- | ----------------------------------------- |
 | Bootstrap a new fork                           | `finpilot-onboarding`                  |
+| Set up promotion / stable branch / release gate | `finpilot-onboarding`, `finpilot-ci`   |
 | Add/remove a package                           | `finpilot-packages`                    |
 | Change Brewfiles, Flatpaks, or ujust           | `finpilot-custom`                      |
 | Change Containerfile, Justfile, or build/\*.sh | `finpilot-build`                       |

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -38,8 +38,21 @@ git switch main
 ```
 
 - [ ] Never commit directly to `stable`; it receives only promotion PRs
-- [ ] Enable keyless signing (see "Enable Signing" below) so the promotion
-      release gate can verify image signatures and report `release/ready`
+- [ ] Keyless signing is enabled by default; after the first build, verify it
+      (see "Verify Image Signing" below) so the promotion release gate can
+      check signatures and report `release/ready`
+
+Promotion PR requirements:
+
+- The promote workflow requests review from `<owner>/maintainers` when it
+  creates the PR — your repo must live in an org with that team, or replace
+  `promote-main-to-stable.yml` with a local workflow that skips reviewer
+  requests (the reviewer is set inside the shared `projectbluefin/actions`
+  reusable, so editing only your caller file won't change it)
+- Set `stable`'s required approvals to choose your automation level: `0` =
+  fully automatic promotion, `1` = a maintainer approves, then auto-merge
+- The release gate is advisory by default; add the promote workflow as a
+  required check on `stable` if a `release/blocked` result should block merges
 
 ### 4. First Push
 
@@ -105,16 +118,23 @@ sudo systemctl reboot
 
 ## Optional: Production Features
 
-### Enable Signing (Recommended)
+### Verify Image Signing (Enabled by Default)
 
-This template uses keyless OIDC signing — no keys or secrets are required.
+Images are signed automatically with keyless OIDC signing — no keys or
+secrets to configure. After the first green build, verify the signature:
 
-- [ ] Edit `.github/workflows/build-image.yml`
-- [ ] Find the "OPTIONAL: Sign and attest" section
-- [ ] Uncomment the `Sign and publish` step
-- [ ] Commit and push (via PR to `main`)
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/YOUR_USERNAME/YOUR_REPO/.github/workflows/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  ghcr.io/YOUR_USERNAME/YOUR_REPO:stable-testing
+```
 
-**Agent skill:** `finpilot-templates` (signing setup)
+To disable signing (not recommended), comment out the `Sign and publish`
+step in `.github/workflows/build-image.yml`. Unsigned images fail the
+promotion release gate (`release/blocked`).
+
+**Agent skill:** `finpilot-templates` (signing verification)
 
 ### Enable Rechunking (Optional)
 
@@ -138,7 +158,7 @@ Which skill to load for each checklist block above:
 | Branches + promotion (step 3)         | `finpilot-onboarding`, `finpilot-ci`        |
 | Renovate + branch protection (step 5) | `finpilot-onboarding`, `finpilot-ci`        |
 | Raptor section (step 6)               | `finpilot-onboarding`, `finpilot-maintain`  |
-| Signing (optional)                    | `finpilot-templates`                        |
+| Signing verification (default on)     | `finpilot-templates`                        |
 | Rechunking (optional)                 | `finpilot-ci`                               |
 
 **Cross-link requirement**: Whenever you add or remove a package, app, or service **after** initial setup, update the README raptor section and its `*Last updated*` date. This is required by the `finpilot-maintain` skill.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ Use @projectbluefin/finpilot as a template, name the OS the repository name. Ens
 
 **Phase 3 — Production:**
 
-1. Enable keyless signing by uncommenting the step in `.github/workflows/build-image.yml`
+1. Keyless signing is enabled by default in `.github/workflows/build-image.yml`
 2. Verify with: `cosign verify --certificate-identity-regexp="https://github.com/USER/REPO/.github/workflows/" --certificate-oidc-issuer="https://token.actions.githubusercontent.com" ghcr.io/USER/REPO:stable`
 3. Use the `finpilot-maintain` skill for the ongoing maintenance schedule
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Use the `finpilot-maintain` and `finpilot-ci` skills, then:
 - Automatic cleanup of old images (90+ days) to keep it tidy
 - Pull request workflow - test changes before merging to main
   - PRs build and validate before merge
-  - `main` branch builds `:stable` images
+  - `main` builds `:stable-testing`; merging the auto-opened promotion PR to `stable` publishes `:stable`
 - Validates your files on pull requests so you never break a build:
   - Brewfile, Justfile, ShellCheck, Renovate config, and it'll even check to make sure the flatpak you add exists on FlatHub
 - Production Grade Features
@@ -225,14 +225,38 @@ All changes should be made via pull requests:
    - Brewfile, Flatpak, Justfile, and shellcheck validation
    - Test image build
 3. Once checks pass, merge the PR
-4. Merging triggers publishes a `:stable` image
+4. Merging to `main` publishes a `:stable-testing` image; the promotion PR it opens publishes `:stable` when merged
 
-### 8. Deploy Your Image
+### 8. Promote to Stable
 
-Switch to your image:
+The template uses a two-branch release model:
+
+| Branch   | Image tag                        | Audience                       |
+| -------- | -------------------------------- | ------------------------------ |
+| `main`   | `:stable-testing` (+ `:testing`) | Testers and release candidates |
+| `stable` | `:stable`                        | Production systems             |
+
+When `stable` differs from `main`, the [`promote-main-to-stable`](.github/workflows/promote-main-to-stable.yml) workflow opens a squash promotion PR automatically, enables auto-merge, and runs a release gate that verifies image signatures on `:testing`. Direct pushes to `stable` are not part of the workflow; hotfixes made there are merged back into `main` by [`sync-stable-to-main`](.github/workflows/sync-stable-to-main.yml).
+
+For the automated promotion PR to open, your repository needs:
+
+- An **organization-owned repo with a `maintainers` team** — the workflow requests review from `<owner>/maintainers` when creating the PR. Personal-account forks can replace `.github/workflows/promote-main-to-stable.yml` with a local version that skips reviewer requests.
+- Branch protection on `stable`: **0 required approvals** means fully automatic promotion; **1 approval** means review, then auto-merge.
+- The release gate is advisory by default — make the promote workflow a required check on `stable` if a `release/blocked` result should block merging.
+
+### 9. Deploy Your Image
+
+Test the candidate from `main` first:
 
 ```bash
-sudo bootc switch ghcr.io/your-username/your-repo-name:stable
+sudo bootc switch --transport registry ghcr.io/your-username/your-repo-name:stable-testing
+sudo systemctl reboot
+```
+
+After merging the promotion PR, deploy production:
+
+```bash
+sudo bootc switch --transport registry ghcr.io/your-username/your-repo-name:stable
 sudo systemctl reboot
 ```
 

--- a/custom/flatpaks/README.md
+++ b/custom/flatpaks/README.md
@@ -1,6 +1,6 @@
 # Flatpak Preinstall Integration
 
-This directory contains Flatpak preinstall configuration files that will be copied into your custom image at `/etc/flatpak/preinstall.d/`.
+This directory contains Flatpak preinstall configuration files that will be copied into your custom image at `/usr/share/flatpak/preinstall.d/`.
 
 ## What is Flatpak Preinstall?
 
@@ -8,7 +8,7 @@ Flatpak preinstall is a feature that allows system administrators to define Flat
 
 ## How It Works
 
-1. **During Build**: Files in this directory are copied to `/etc/flatpak/preinstall.d/` in the image
+1. **During Build**: Files in this directory are copied to `/usr/share/flatpak/preinstall.d/` in the image
 2. **On First Boot**: After user setup completes, the system reads these files and installs the specified Flatpaks
 3. **User Experience**: Applications appear automatically after first login
 
@@ -51,7 +51,7 @@ See: https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-p
 
 1. Edit [`default.preinstall`](default.preinstall) or create new `.preinstall` files in this directory
 2. Add Flatpak references in INI format with `[Flatpak Preinstall NAME]` sections
-3. Build your image - the files will be copied to `/etc/flatpak/preinstall.d/`
+3. Build your image - the files will be copied to `/usr/share/flatpak/preinstall.d/`
 4. After user setup completes, Flatpaks will be automatically installed
 
 **Example Files in this directory:**


### PR DESCRIPTION
## Summary

Doc-only housekeeping aligning template docs with current behavior:

- **Promotion docs (new)**: dedicated "Promote to Stable" section in README (two-branch table + requirements), promotion PR requirements in SETUP_CHECKLIST step 3, setup section in \`finpilot-onboarding\`, routing row in \`finpilot-router\`. Behavioral claims verified against \`reusable-promote-squash.yml\` source (\`--reviewer <owner>/maintainers\`, auto-merge honoring required approvals, advisory release gate).
- **Stale signing instructions**: SETUP_CHECKLIST "uncomment Sign and publish" and copilot-instructions Phase 3 replaced with verify-signing guidance (keyless signing is default-on since #271).
- **Branch-model corrections**: "main builds :stable" claims fixed to \`:stable-testing\` + promotion flow; deploy section now tests the candidate image before production.
- **Path fix**: \`custom/flatpaks/README.md\` preinstall.d path corrected to \`/usr/share/flatpak/preinstall.d/\` (verified against projectbluefin/common's \`flatpak-preinstall.service\`).
- **Skill accuracy**: \`finpilot-build\` default-package exception is \`tmux gum\`; \`finpilot-onboarding\` first-build tags corrected to \`:stable-testing\`/\`:testing\`.
- **Self-improvement**: repo-wide doc-sweep dot-directory gotcha added to \`finpilot-pr-checklist\`.

Two-axis review passed: standards 0 hard violations; spec S1-S7 complete with claims source-verified.

Assisted-by: ox-alpha via OpenCode