### PR TITLE
fix(just): repair clean recipe so it finishes and removes all artifacts

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -51,12 +51,11 @@ fix:
 clean:
     #!/usr/bin/bash
     set -eoux pipefail
-    touch _build
-    find *_build* -exec rm -rf {} \;
+    find . -maxdepth 1 -name '*_build*' -prune -exec rm -rf {} +
     rm -f previous.manifest.json
     rm -f changelog.md
     rm -f output.env
-    rm -f output/
+    rm -rf output/
 
 # Sudo Clean Repo
 [group('Utility')]


### PR DESCRIPTION
find with -prune/-maxdepth stops the descend-after-rm failure that aborted the recipe under set -e; rm -rf handles the output/ directory that rm -f could never remove. Drops the touch _build glob guard.

Verified: seeded sandbox (my_build/, output/, three manifest files) fully cleaned with exit 0; empty run exit 0; unrelated files preserved. just --list and fmt --check pass.

Closes #300

Assisted-by: Muse Spark via OpenCode