### PR TITLE
fix(just): build IMAGE_NAME from target_image so renames upgrade correctly

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -142,7 +142,7 @@ build $target_image=IMAGE_NAME $tag=DEFAULT_TAG:
 
     # Image identity ARGs - these define how bootc/ublue ecosystem recognizes the image
     # Override via env vars: IMAGE_NAME, IMAGE_VENDOR, UBLUE_IMAGE_TAG
-    BUILD_ARGS+=("--build-arg" "IMAGE_NAME=${IMAGE_NAME:-${target_image}}")
+    BUILD_ARGS+=("--build-arg" "IMAGE_NAME=${target_image}")
     BUILD_ARGS+=("--build-arg" "IMAGE_VENDOR=${IMAGE_VENDOR:-${REPO_ORG}}")
     BUILD_ARGS+=("--build-arg" "UBLUE_IMAGE_TAG=${UBLUE_IMAGE_TAG:-${tag}}")
 

--- a/tests/unit/justfile-build_test.bats
+++ b/tests/unit/justfile-build_test.bats
@@ -190,16 +190,15 @@ podman_build_args() {
     [[ "${args}" == *"--build-arg UBLUE_IMAGE_TAG=pinned"* ]]
 }
 
-# Characterization test: `IMAGE_NAME` is exported by the Justfile itself with a
-# default of "finpilot", so `${IMAGE_NAME:-${target_image}}` can never fall back
-# to the positional target_image. Building under a different name therefore
-# still labels the image identity "finpilot". Pinned here so a fix is visible.
-@test "build: IMAGE_NAME build arg ignores the positional target_image" {
+# The positional target_image wins for the image identity: `target_image`
+# already defaults to IMAGE_NAME, so the default invocation is unchanged
+# while `just build otherimage stable` now labels the identity "otherimage".
+@test "build: IMAGE_NAME build arg follows the positional target_image" {
     run_just build otherimage stable
     [ "$status" -eq 0 ]
     local args
     args="$(podman_build_args)"
-    [[ "${args}" == *"--build-arg IMAGE_NAME=finpilot"* ]]
+    [[ "${args}" == *"--build-arg IMAGE_NAME=otherimage"* ]]
     [[ "${args}" == *"--tag otherimage:stable"* ]]
 }
 


### PR DESCRIPTION
IMAGE_NAME is always exported with a default, so the ${IMAGE_NAME:-${target_image}} fallback was unreachable and every build stamped finpilot into image-info.json/image-ref. target_image already defaults to IMAGE_NAME, preserving the env-override path. Flips the characterization test to assert the fixed behaviour.

Verified with stubbed podman/skopeo (mirrors tests/unit/justfile-build_test.bats): otherimage build stamps IMAGE_NAME=otherimage; default and IMAGE_NAME=custom override paths unchanged.

Closes #297

Assisted-by: Muse Spark via OpenCode