### PR TITLE
fix(just): use a per-invocation temp file for the registry tag list

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -121,8 +121,8 @@ build $target_image=IMAGE_NAME $tag=DEFAULT_TAG:
 
     # Avoid tag collisions when rebuilding on the same day
     if command -v skopeo &>/dev/null; then
-        repotags=$(mktemp -t repotags.XXXXXXXX.json)
-        trap "rm -f \"${repotags}\"" EXIT
+        repotags=$(mktemp -t repotags.XXXXXXXX.json) || { echo "ERROR: mktemp failed to create tag-list temp file"; exit 1; }
+        trap 'rm -f "${repotags}"' EXIT
         skopeo list-tags "docker://ghcr.io/${IMAGE_VENDOR:-${REPO_ORG}}/${target_image}" >"${repotags}" 2>/dev/null \
             || echo '{"Tags":[]}' >"${repotags}"
         if [[ $(jq "any(.Tags[]; contains(\"${ver}\"))" "${repotags}") == "true" ]]; then

--- a/Justfile
+++ b/Justfile
@@ -122,11 +122,13 @@ build $target_image=IMAGE_NAME $tag=DEFAULT_TAG:
 
     # Avoid tag collisions when rebuilding on the same day
     if command -v skopeo &>/dev/null; then
-        skopeo list-tags "docker://ghcr.io/${IMAGE_VENDOR:-${REPO_ORG}}/${target_image}" >/tmp/repotags.json 2>/dev/null \
-            || echo '{"Tags":[]}' >/tmp/repotags.json
-        if [[ $(jq "any(.Tags[]; contains(\"${ver}\"))" /tmp/repotags.json) == "true" ]]; then
+        repotags=$(mktemp -t repotags.XXXXXXXX.json)
+        trap "rm -f \"${repotags}\"" EXIT
+        skopeo list-tags "docker://ghcr.io/${IMAGE_VENDOR:-${REPO_ORG}}/${target_image}" >"${repotags}" 2>/dev/null \
+            || echo '{"Tags":[]}' >"${repotags}"
+        if [[ $(jq "any(.Tags[]; contains(\"${ver}\"))" "${repotags}") == "true" ]]; then
             POINT=1
-            while [[ $(jq "any(.Tags[]; contains(\"${ver}.${POINT}\"))" /tmp/repotags.json) == "true" ]]; do
+            while [[ $(jq "any(.Tags[]; contains(\"${ver}.${POINT}\"))" "${repotags}") == "true" ]]; do
                 ((POINT++))
             done
             ver="${ver}.${POINT}"


### PR DESCRIPTION
A hardcoded /tmp/repotags.json lets concurrent builds for different target_image values race on one file and gives anyone who pre-creates the path control over the tag-collision check. mktemp + EXIT trap keeps the recipe sandboxable under test with no caller-visible change.

Verified with stubbed skopeo: no /tmp/repotags.json created, collision bump still works (44.20260830.1), temp file removed by trap. Deliberately leaves the missing set -euo pipefail noted in the issue untouched to keep blast radius to one fix.

Closes #298

Assisted-by: Muse Spark via OpenCode