### PR TITLE
fix(ujust): stop install-jetbrains-toolbox when the checksum fails

### DIFF
--- a/custom/ujust/custom-apps.just
+++ b/custom/ujust/custom-apps.just
@@ -40,6 +40,7 @@ install-all-brew:
 [group('Apps')]
 install-jetbrains-toolbox:
     #!/usr/bin/env bash
+    set -euo pipefail
     echo "Installing JetBrains Toolbox..."
     pushd "$(mktemp -d)"
     echo "Fetching latest version..."

--- a/tests/unit/custom-apps-just_test.bats
+++ b/tests/unit/custom-apps-just_test.bats
@@ -222,17 +222,15 @@ _log_line() {
     grep -qF "jetbrains-toolbox launched" "${COMMAND_LOG}"
 }
 
-@test "install-jetbrains-toolbox: characterizes the un-gated checksum failure" {
-    # KNOWN GAP (characterization test, not an endorsement): the recipe body
-    # has no `set -euo pipefail`, so a failing `sha256sum -c` does not stop the
-    # recipe — the unverified tarball is still extracted and executed. This test
-    # pins the current behaviour so a future fix that adds the guard shows up as
-    # an intentional, reviewed change to this assertion rather than a silent one.
+@test "install-jetbrains-toolbox aborts before extracting when the checksum fails" {
+    # The recipe body has `set -euo pipefail`, so a failing `sha256sum -c`
+    # stops the recipe — the unverified tarball is never extracted or run.
     _run_recipe "install-jetbrains-toolbox" MOCK_SHA_OK=0
 
+    [ "${status}" -ne 0 ]
     grep -qF "sha256sum -c" "${COMMAND_LOG}"
-    [ "$(grep -cF "tar zxf" "${COMMAND_LOG}")" -eq 1 ]
-    [ -x "${HOME}/.local/share/JetBrains/ToolboxApp/bin/jetbrains-toolbox" ]
+    [ "$(grep -cF "tar zxf" "${COMMAND_LOG}")" -eq 0 ]
+    [ ! -e "${HOME}/.local/share/JetBrains/ToolboxApp/bin/jetbrains-toolbox" ]
 }
 
 @test "install-jetbrains-toolbox resolves the build version from the releases feed" {


### PR DESCRIPTION
The recipe had no set -euo pipefail, so a failing sha256sum -c still extracted and executed the unverified tarball. The guard makes checksum verification blocking. Flips the characterization test to assert the abort; other brew recipes deliberately untouched (install-all-brew's test pins its retry-all behaviour).

Verified by replicating tests/unit/custom-apps-just_test.bats mocks: checksum fail -> status 1, tar 0 invocations, binary absent; checksum ok -> status 0, binary installed.

Closes #294

Assisted-by: Muse Spark via OpenCode