### PR TITLE
fix(ci): stop inheriting all repo secrets in label-enforcement

### DIFF
--- a/.github/workflows/label-enforcement.yml
+++ b/.github/workflows/label-enforcement.yml
@@ -14,6 +14,5 @@ permissions:
 jobs:
   enforce:
     uses: projectbluefin/actions/.github/workflows/reusable-design-enforcement.yml@ce7ab75eb66d3ace300fed4c121a31b417e8f9fe
-    secrets: inherit
     with:
       required-field-groups: '[["What happened?","What would you like to see?","What specifically should the agent focus on?"]]'


### PR DESCRIPTION
Removes secrets: inherit from the issues/pull_request-triggered caller. The SHA-pinned reusable declares no secret inputs and uses only github.token. Same patch the sec-check agent had ready but could not push without workflows scope.

Closes #289

Assisted-by: Muse Spark via OpenCode