### PR TITLE
docs: document E2E gap as intentional release risk (#281)

### DIFF
--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -44,5 +44,13 @@ jobs:
       # The release gate resolves the :testing tag (published by main builds)
       # and verifies its cosign signature. Enable the OPTIONAL keyless signing
       # step in build-image.yml for the gate to report release/ready.
+      #
+      # KNOWN GAP (see #281): run_e2e is false because finpilot has no
+      # post-build/post-merge E2E workflow and no e2e_image configured for
+      # the shared gate to exercise. Stable promotion is therefore gated on
+      # digest + cosign signature checks only, not on functional E2E
+      # validation. This is an intentional, documented release risk (see
+      # README.md "Promote to Stable") until an E2E workflow and
+      # `e2e_image`/`e2e_suites` inputs are added here.
       run_e2e: false
     secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,9 @@ links lives in `.agents/skills/README.md`.
 The promotion release gate verifies cosign signatures on the `:testing` tag;
 keyless signing is enabled by default in `build-image.yml` ("Sign and publish"
 step) and reports `release/ready` once a signed `:testing` image exists.
+**Known gap:** the gate does not run E2E validation (`run_e2e: false`, no
+`e2e_image` configured) — `release/ready` means "signed," not "functionally
+tested." See README.md "Promote to Stable" and issue #281.
 
 ## CRITICAL: GitHub API Usage
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ For the automated promotion PR to open, your repository needs:
 - Branch protection on `stable`: **0 required approvals** means fully automatic promotion; **1 approval** means review, then auto-merge.
 - The release gate is advisory by default — make the promote workflow a required check on `stable` if a `release/blocked` result should block merging.
 
+> **Known release risk:** the release gate currently checks digest and cosign signature only — `run_e2e` is `false` in `promote-main-to-stable.yml` because this repository has no post-build/post-merge E2E workflow or `e2e_image` configured for the shared gate to exercise. Until an E2E workflow is added and `run_e2e: true` (with `e2e_image`/`e2e_suites`) is configured, treat a `release/ready` result as "signed and unmodified," not "functionally validated." See [#281](https://github.com/projectbluefin/finpilot/issues/281).
+
 ### 9. Deploy Your Image
 
 Test the candidate from `main` first:


### PR DESCRIPTION
## Summary

Closes #281

The scanner agent found that `promote-main-to-stable.yml` passes `run_e2e: false` to the shared `reusable-promote-squash.yml` workflow, and finpilot has no E2E workflow or `e2e_image` configured. So stable promotion currently only verifies digest + cosign signature, not functional behavior — but the promotion PR/gate doesn't call that out anywhere.

Building a real E2E workflow requires design decisions (which suites, which `e2e_image`) that are owned by the shared `projectbluefin/actions` tooling and aren't finalized even for the org's flagship images — `bluefin` and `bluefin-lts` promotion workflows also currently set `run_e2e: false`. Rather than guessing at that design, this PR takes the issue's own fallback recommendation: **document the gap as an intentional release risk** until an E2E workflow and `run_e2e: true` / `e2e_image` / `e2e_suites` are added.

## Changes

- `.github/workflows/promote-main-to-stable.yml`: expanded the comment above `run_e2e: false` explaining the known gap and linking to #281.
- `README.md`: added a callout under "Promote to Stable" clarifying that `release/ready` means "signed and unmodified," not "functionally validated," until E2E is wired up.
- `AGENTS.md`: added the same clarification to the release workflow section agents rely on.

## Testing

Documentation-only change; validated the workflow YAML still parses (`python3 -c "import yaml; yaml.safe_load(...)"`).

— hive: backend=copilot model=claude-haiku-4.5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `bf0b8b5`