### PR TITLE
ci(promote): require per-HEAD E2E run for main-to-stable promotion

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -57,6 +57,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      actions: write # dispatch post-merge-e2e.yml for the promotion release gate
 
     steps:
       - name: Prepare environment
@@ -268,6 +269,31 @@ jobs:
           push-attestation: true
           certificate-identity-regexp: https://github.com/${{ github.repository }}/.github/workflows/
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Per-HEAD E2E gate run for the main → stable promotion release gate
+      # (issue #284). The shared promotion gate requires a successful
+      # Post-Merge E2E run recorded on the promoted main HEAD SHA; dispatch
+      # one now that this build's digest is on :testing. The expected-digest
+      # binding makes the run fail if :testing no longer points at what this
+      # build pushed. Functional smoke inside that workflow is advisory and
+      # opt-in (E2E_ADVISORY_SMOKE repo variable) — see post-merge-e2e.yml.
+      - name: Dispatch Post-Merge E2E for promotion gate
+        if: github.event_name != 'pull_request' && github.ref_name == 'main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          OWNER: ${{ github.repository_owner }}
+          PUSH_DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          IMAGE_REF="ghcr.io/$(echo "${OWNER}" | tr '[:upper:]' '[:lower:]')/${IMAGE_NAME}:testing"
+          gh workflow run post-merge-e2e.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f image="${IMAGE_REF}" \
+            -f expected-digest="${PUSH_DIGEST}" \
+            -f suites="smoke"
+          echo "Dispatched Post-Merge E2E for ${IMAGE_REF}@${PUSH_DIGEST}"
 
       - name: Build telemetry summary
         if: steps.detect-changes.outputs.should_build == 'true' || github.event_name != 'pull_request'

--- a/.github/workflows/post-merge-e2e.yml
+++ b/.github/workflows/post-merge-e2e.yml
@@ -1,0 +1,123 @@
+---
+name: Post-Merge E2E
+
+# Per-commit E2E gate run for the main → stable promotion release gate
+# (promote-main-to-stable.yml passes run_e2e: true — issue #284).
+#
+# The shared gate (projectbluefin/actions reusable-promote-squash.yml →
+# reusable-release-gate.yml) resolves E2E runs by head SHA: it requires a
+# completed, successful run of a workflow named post-merge-e2e.yml or
+# post-testing-e2e.yml recorded on the promoted main HEAD. This file's NAME
+# and PATH are load-bearing for that lookup — rename only together with the
+# gate's selector.
+#
+# Triggers:
+#   - build-image.yml dispatches it after every main-branch image build,
+#     passing the pushed digest as expected-digest (tag↔digest binding).
+#   - promote-main-to-stable.yml backfills dispatches for main heads with no
+#     recorded run (docs-only pushes skip the build via paths-ignore).
+#
+# What the blocking gate verifies (bluefin-lts post-testing-e2e.yml pattern):
+#   - :testing resolves to the digest the build pushed (when expected-digest
+#     is provided), and
+#   - the manifest is well-formed OCI/Docker image metadata.
+#
+# Functional desktop smoke is intentionally NOT a promotion blocker yet:
+# suite selection and thresholds for the shared factory are an open design
+# decision tracked in #281 (docs: #328). When the repository variable
+# E2E_ADVISORY_SMOKE=1 is set, this workflow additionally fires the
+# testsuite smoke suite via run-testsuite.yml against the exact verified
+# digest. That run is fire-and-forget: it surfaces as its own workflow run
+# and commit check, and can never flip the promotion gate.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: Full image reference to test
+        required: false
+        default: ghcr.io/projectbluefin/finpilot:testing
+        type: string
+      suites:
+        description: Comma-separated list of test suites to run (advisory smoke)
+        required: false
+        default: smoke
+        type: string
+      expected-digest:
+        description: Expected immutable digest for the image (from the build that dispatched this run)
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+  packages: write # testsuite pushes screenshot OCI artifacts to GHCR
+
+concurrency:
+  group: post-merge-e2e-${{ github.event.inputs.image || 'default' }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Verify release image
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      verified_ref: ${{ steps.verify.outputs.verified_ref }}
+    steps:
+      - name: Verify image digest and manifest
+        id: verify
+        env:
+          EXPECTED_DIGEST: ${{ inputs.expected-digest }}
+          IMAGE_REF: ${{ inputs.image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Checking image manifest for ${IMAGE_REF}"
+          actual_digest="$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REF}")"
+          if [[ -n "${EXPECTED_DIGEST}" && "${actual_digest}" != "${EXPECTED_DIGEST}" ]]; then
+            echo "::error::${IMAGE_REF} resolved to ${actual_digest}, expected ${EXPECTED_DIGEST}"
+            exit 1
+          fi
+          raw_manifest="$(skopeo inspect --raw "docker://${IMAGE_REF}")"
+          echo "${raw_manifest}" | jq -e '
+            (.mediaType == "application/vnd.oci.image.index.v1+json"
+              or .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json"
+              or .mediaType == "application/vnd.oci.image.manifest.v1+json"
+              or .mediaType == "application/vnd.docker.distribution.manifest.v2+json")
+          ' >/dev/null
+          echo "Verified ${IMAGE_REF} -> ${actual_digest} is a well-formed image manifest."
+          # Pin to the immutable digest for downstream jobs (base ref, no tag).
+          base="${IMAGE_REF%%@*}"
+          base="${base%:*}"
+          echo "verified_ref=${base}@${actual_digest}" >> "$GITHUB_OUTPUT"
+
+  # Advisory (non-blocking) functional smoke — see workflow header. Gated on
+  # the E2E_ADVISORY_SMOKE repository variable and on the verification job
+  # above, so smoke always tests the exact digest the gate verified.
+  # continue-on-error is not permitted on reusable-workflow call jobs, so
+  # instead of calling run-testsuite.yml inline this dispatches it: the
+  # dispatched run is independent and can never fail this gate run.
+  dispatch-advisory-smoke:
+    name: Dispatch advisory smoke (non-blocking)
+    needs: [e2e]
+    if: vars.E2E_ADVISORY_SMOKE == '1' && needs.e2e.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Fire testsuite smoke against the verified digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_REF: ${{ needs.e2e.outputs.verified_ref }}
+          REPO: ${{ github.repository }}
+          SUITES: ${{ inputs.suites }}
+        run: |
+          gh workflow run run-testsuite.yml \
+            --repo "${REPO}" \
+            --ref main \
+            -f image="${IMAGE_REF}" \
+            -f suites="${SUITES}"
+          echo "Dispatched advisory smoke for ${IMAGE_REF} (suites: ${SUITES})."

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -10,11 +10,30 @@ name: Promote main to stable
 # matching the pattern in projectbluefin/bluefin and projectbluefin/bluefin-lts.
 # pull[bot] was considered and rejected: the factory reusable is auditable,
 # org-maintained, and shared with the other image repos (see issues #235/#237).
+#
+# E2E release gate (issue #284): the shared gate requires a completed,
+# successful `Post-Merge E2E` run (post-merge-e2e.yml) recorded on the
+# promoted main HEAD SHA before it reports release/ready. build-image.yml
+# dispatches that run after every main build; dispatch-missing-e2e below
+# backfills it for pushes that skip the build (docs-only changes). Each
+# completed Post-Merge E2E run re-triggers this workflow via workflow_run,
+# so the promotion PR's gate section self-heals once the run lands.
 
 on:
   push:
     branches:
       - main
+  # Re-evaluate the promotion once the Post-Merge E2E run for the current
+  # main HEAD completes (success or failure — a failed run must flip the
+  # promotion PR to release/blocked).
+  workflow_run:
+    workflows: ["Post-Merge E2E"]
+    types: [completed]
+    branches: [main]
+  # Daily reconciliation (matches the bluefin/bluefin-lts cadence) so a
+  # promotion PR never waits on a missed trigger.
+  schedule:
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 permissions:
@@ -32,6 +51,9 @@ concurrency:
 jobs:
   promote:
     name: Promote main to stable
+    # workflow_run events fire for failed E2E runs too. Re-evaluating on a
+    # failed run is intentional: the gate finds the failed run and flips the
+    # promotion PR to release/blocked. Nothing here needs skipping.
     uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@9c699818ddf1043b8f5af8b862f59f783c6c7bda # v1
     with:
       variants: >-
@@ -41,8 +63,58 @@ jobs:
       registry: ghcr.io/${{ github.repository_owner }}
       source_branch: main
       target_branch: stable
-      # The release gate resolves the :testing tag (published by main builds)
-      # and verifies its cosign signature. Enable the OPTIONAL keyless signing
-      # step in build-image.yml for the gate to report release/ready.
-      run_e2e: false
+      # Release gate (issue #284): digest and cosign checks alone no longer
+      # report release/ready. The gate additionally requires a successful
+      # Post-Merge E2E run recorded on the promoted main HEAD SHA. The
+      # OPTIONAL keyless signing step in build-image.yml must stay enabled
+      # for the cosign leg to pass.
+      run_e2e: true
+      e2e_image: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:testing
+      e2e_suites: smoke
     secrets: inherit
+
+  # The release gate requires a successful Post-Merge E2E run on the current
+  # main HEAD, but build-image.yml only dispatches one after an image build —
+  # and its paths-ignore skips the build entirely for docs-only pushes. When
+  # no run is recorded for HEAD, backfill one: each completed run re-triggers
+  # this workflow (workflow_run), the gate then finds it, and the promotion
+  # PR recovers. Pattern: bluefin-lts promote-testing-to-main.yml.
+  dispatch-missing-e2e:
+    name: Backfill E2E for main head
+    if: github.event_name != 'workflow_run'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Dispatch Post-Merge E2E when no successful run exists for HEAD
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          main_head="$(gh api "repos/${REPO}/branches/main" --jq '.commit.sha')"
+          echo "Main HEAD: ${main_head}"
+
+          existing="$(gh run list \
+            --repo "${REPO}" \
+            --workflow post-merge-e2e.yml \
+            --branch main \
+            --status success \
+            --json headSha \
+            --jq "[.[] | select(.headSha == \"${main_head}\")] | length")"
+
+          if [[ "${existing}" == "0" ]]; then
+            # No expected-digest here: this backfill path has no fresh build
+            # to bind to, so the run verifies whatever :testing currently
+            # serves. Build-triggered runs (build-image.yml) carry the
+            # expected-digest binding instead.
+            gh workflow run post-merge-e2e.yml \
+              --repo "${REPO}" \
+              --ref main
+            echo "Dispatched Post-Merge E2E for ${main_head}."
+          else
+            echo "Successful Post-Merge E2E already recorded for ${main_head}; skipping dispatch."
+          fi

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -1,0 +1,48 @@
+name: Run Testsuite
+
+# Canonical wrapper — always call this, never call projectbluefin/testsuite e2e.yml directly.
+# Uses @v1 managed tag — testsuite auto-tracks v1 to main on every merge via update-v1-tag.yml.
+# Never SHA-pin this ref; use @v1 so E2E picks up testsuite fixes immediately.
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Full image reference to test (e.g. ghcr.io/projectbluefin/finpilot:testing)"
+        required: true
+        type: string
+      suites:
+        description: "Comma-separated list of test suites to run"
+        required: true
+        type: string
+  # Also dispatchable so advisory (non-gating) smoke runs can be fired from
+  # post-merge-e2e.yml and manually from the Actions UI against any image ref.
+  # The `inputs` context resolves for both workflow_call and workflow_dispatch.
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Full image reference to test (e.g. ghcr.io/projectbluefin/finpilot:testing)"
+        required: true
+        type: string
+      suites:
+        description: "Comma-separated list of test suites to run"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write # testsuite pushes screenshot OCI artifacts to GHCR
+
+jobs:
+  e2e:
+    name: ${{ inputs.suites }}
+    permissions:
+      contents: read
+      packages: write  # testsuite pushes screenshot OCI artifacts to GHCR
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@v1
+    with:
+      image: ${{ inputs.image }}
+      suites: ${{ inputs.suites }}
+      # Keep the checked-out tests aligned with the managed workflow tag.
+      # Defaulting to testsuite/main can gate finpilot on unreleased test changes.
+      test_ref: v1
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,13 @@ links lives in `.agents/skills/README.md`.
 
 The promotion release gate verifies cosign signatures on the `:testing` tag;
 keyless signing is enabled by default in `build-image.yml` ("Sign and publish"
-step) and reports `release/ready` once a signed `:testing` image exists.
+step) and reports `release/ready` once a signed `:testing` image exists. As of
+#284 the gate also requires a successful `Post-Merge E2E` run — digest and
+manifest verification dispatched by `build-image.yml` per main HEAD and
+backfilled by the promotion workflow — before reporting `release/ready`.
+Functional desktop smoke is advisory and opt-in (repository variable
+`E2E_ADVISORY_SMOKE=1`); making it blocking is pending the suite-selection
+decision in #281.
 
 ## CRITICAL: GitHub API Usage
 

--- a/README.md
+++ b/README.md
@@ -245,13 +245,14 @@ The template uses a two-branch release model:
 | `main`   | `:stable-testing` (+ `:testing`) | Testers and release candidates |
 | `stable` | `:stable`                        | Production systems             |
 
-When `stable` differs from `main`, the [`promote-main-to-stable`](.github/workflows/promote-main-to-stable.yml) workflow opens a squash promotion PR automatically, enables auto-merge, and runs a release gate that verifies image signatures on `:testing`. Direct pushes to `stable` are not part of the workflow; hotfixes made there are merged back into `main` by [`sync-stable-to-main`](.github/workflows/sync-stable-to-main.yml).
+When `stable` differs from `main`, the [`promote-main-to-stable`](.github/workflows/promote-main-to-stable.yml) workflow opens a squash promotion PR automatically, enables auto-merge, and runs a release gate that verifies image signatures and a per-commit `Post-Merge E2E` check on `:testing`. Direct pushes to `stable` are not part of the workflow; hotfixes made there are merged back into `main` by [`sync-stable-to-main`](.github/workflows/sync-stable-to-main.yml).
 
 For the automated promotion PR to open, your repository needs:
 
 - An **organization-owned repo with a `maintainers` team** — the workflow requests review from `<owner>/maintainers` when creating the PR. Personal-account forks can replace `.github/workflows/promote-main-to-stable.yml` with a local version that skips reviewer requests.
 - Branch protection on `stable`: **0 required approvals** means fully automatic promotion; **1 approval** means review, then auto-merge.
 - The release gate is advisory by default — make the promote workflow a required check on `stable` if a `release/blocked` result should block merging.
+- The gate also requires a successful per-commit `Post-Merge E2E` run (digest/manifest verification dispatched by `build-image.yml`) for `release/ready`; functional desktop smoke is opt-in via the `E2E_ADVISORY_SMOKE` repository variable pending [#281](https://github.com/projectbluefin/finpilot/issues/281).
 
 ### 9. Deploy Your Image
 


### PR DESCRIPTION
## Summary

Closes #284

The caller workflow `.github/workflows/promote-main-to-stable.yml` passed `run_e2e: false` to the shared `reusable-promote-squash.yml`, so main → stable promotion PRs reported `E2E ⏭️ skipped — Caller disabled the E2E gate` and release readiness rested on digest + cosign checks alone (visible today on PR #321).

## What this does

Enables the E2E release gate following the **bluefin-lts reference implementation** — the org's only `run_e2e: true` caller (`promote-testing-to-main.yml` with `e2e_image: ghcr.io/projectbluefin/bluefin-lts:testing` plus a per-build verification run):

- **`promote-main-to-stable.yml`**
  - `run_e2e: true` + explicit `e2e_image: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:testing` + `e2e_suites: smoke`. The shared gate now requires a completed, successful `Post-Merge E2E` run recorded on the promoted main HEAD SHA before reporting `release/ready`.
  - Adds triggers: `workflow_run` (re-evaluate when the E2E run for HEAD completes — the PR gate section self-heals from "no run found" to ✅) and a daily 04:00 UTC reconciliation (matches the bluefin/bluefin-lts cadence).
  - Adds a `dispatch-missing-e2e` backfill job: pushes that skip the image build (docs-only, via `paths-ignore`) would otherwise leave the HEAD with no E2E run and the gate stuck at `release/blocked`. Backfilled runs verify whatever `:testing` currently serves; build-triggered runs carry the `expected-digest` binding. Pattern ported from bluefin-lts (without its duplicate-dispatch wart).
- **`post-merge-e2e.yml` (new)** — dispatched per main build with the pushed digest; verifies `:testing` still resolves to that digest and that the manifest is well-formed OCI/Docker metadata. The workflow name/path is load-bearing for the shared gate's run lookup (`post-testing-e2e.yml` / `post-merge-e2e.yml` selectors).
- **`build-image.yml`** — dispatches `post-merge-e2e.yml` after publishing `:testing` from main builds (`expected-digest` binding: the run fails if `:testing` no longer points at what that build pushed).
- **`run-testsuite.yml` (new)** — the canonical wrapper around `projectbluefin/testsuite` `e2e.yml@v1` (org convention: never call the testsuite workflow directly), also dispatchable for manual/advisory runs.

## What is intentionally NOT blocking (yet)

Functional desktop smoke. Suite selection and thresholds for the shared factory are an open design decision tracked in #281 (docs-only stopgap in #328). Concretely: the testsuite smoke suite has no per-image filtering — `@bluefin`-tagged features would run against finpilot unvalidated, and wiring an untested QEMU GUI gate as a hard blocker risks permanently `release/blocked` promotions. Instead:

- The enforced gate is the bluefin-lts-style digest/manifest verification, so the E2E row on promotion PRs becomes a real, required, per-commit check instead of a "caller disabled" skip.
- Setting the repository variable `E2E_ADVISORY_SMOKE=1` makes `post-merge-e2e` fire an advisory smoke run against the exact verified digest — fire-and-forget, visible as its own workflow run and commit check, never able to flip the gate. That gives maintainers the data to decide whether/how to make smoke blocking (#281) without risking availability now.

## Coordination

Overlaps textually with open PR #328 (the `run_e2e: false` comment hunk in the same workflow plus the README/AGENTS.md "known gap" callouts). If this merges first, #328 needs a rebase/reword: the gap it documents is closed by this PR, and its callouts should be replaced by the updated gate descriptions included here.

## Testing

- All four workflow files validated against the official GitHub Actions workflow JSON schema (ajv) — notably `continue-on-error` is not permitted on reusable-workflow call jobs, which shaped the advisory-smoke design.
- YAML parse-checked (js-yaml).
- Gate lookup verified against `reusable-release-gate.yml@9c699818`: run selection matches `path endswith post-merge-e2e.yml` (and workflow name "post-merge e2e"); head-SHA matching uses the `source_branch` HEAD as resolved by the shared workflow.
- Trigger/self-heal flow cross-checked against bluefin-lts `promote-testing-to-main.yml` (E2E ✅ rows visible on its merged promotion PRs #563/#564/#565/#567) and bluefin `post-testing-e2e.yml`.
- First live validation comes from this repo's post-merge CI: the merge push runs build-image → post-merge-e2e → promotion re-evaluation.

— hive: backend=goose
