### PR TITLE
fix(ci): create missing stable branch before promotion

### DIFF
--- a/.agents/skills/finpilot-onboarding/SKILL.md
+++ b/.agents/skills/finpilot-onboarding/SKILL.md
@@ -114,6 +114,10 @@ Monitor the workflow. A successful first build:
 - Publishes `:stable-testing` and `:testing` tags to GHCR (`stable` branch builds publish `:stable`)
 - Appears under **Packages** in your repository
 
+The `promote-main-to-stable.yml` workflow creates the `stable` branch from
+`main` on its first run, so a fresh fork does not need a manual `stable`
+branch to start promoting.
+
 ## README "What Makes this Raptor Different" Section
 
 **CRITICAL**: Add this section near the top of `README.md` (after the title/intro, before detailed docs):

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -28,7 +28,8 @@ Promotion is a squash PR from `main` to `stable` opened automatically by
 `.github/workflows/promote-main-to-stable.yml` (factory reusable workflow —
 no external GitHub App required).
 
-Create `stable` as an exact copy of `main`, then return to `main`:
+The promote workflow creates `stable` from `main` on its first run, so the
+manual step below is optional. To create it up front instead:
 
 ```bash
 git switch main

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -30,8 +30,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # First-time forks have no `stable` branch. The factory reusable fetches
+  # origin/stable and fails with exit 128 ("couldn't find remote ref stable"),
+  # which opens "ci: testing→main promotion conflict". Create it once from
+  # current main; later runs no-op when the ref exists.
+  ensure-stable:
+    name: Ensure stable branch exists
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Create stable from main if missing
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin stable >/dev/null; then
+            echo "stable already exists"
+            exit 0
+          fi
+          git push origin "HEAD:stable"
+          echo "Created stable from ${GITHUB_SHA}"
+
   promote:
     name: Promote main to stable
+    needs: ensure-stable
     uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@e2ccd51b41d9bb3abd9caeac626fb15c95589c3c # v1
     with:
       variants: >-


### PR DESCRIPTION
The factory reusable fetches origin/stable and fails when the branch does not exist, opening ci: testing→main promotion conflict. Create stable from main on first run so fresh forks can promote without a manual stable branch.

Assisted-by: grok-4.6 via opencode