### PR TITLE
ci: resolve shellcheck-glob from .shellcheck-scope in pr-validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,14 +21,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - name: Install just
+        env:
+          # renovate: datasource=github-releases depName=casey/just
+          JUST_VERSION: "1.58.0"
+        run: |
+          set -euo pipefail
+          base="https://github.com/casey/just/releases/download/${JUST_VERSION}"
+          asset="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          curl -sSfL -o "${asset}" "${base}/${asset}"
+          curl -sSfL -o SHA256SUMS "${base}/SHA256SUMS"
+          grep -F "${asset}" SHA256SUMS | sha256sum -c -
+          tar xzf "${asset}" -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
+
       - name: Resolve shell lint scope
         id: shell-scope
         shell: bash
         run: |
           set -euo pipefail
-          [[ -f .shellcheck-scope ]] || { echo ".shellcheck-scope is missing" >&2; exit 1; }
-          glob=$(sed 's/#.*//' .shellcheck-scope | tr -d '[:blank:]' | grep -v '^$' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
-          [[ -n "${glob}" ]] || { echo "No patterns found in .shellcheck-scope" >&2; exit 1; }
+          # just shell-sources is the single source of truth for expanding
+          # .shellcheck-scope (see #324) -- `just lint` and CI now share one
+          # expansion implementation instead of two independent parsers.
+          mapfile -t sources < <(just shell-sources)
+          [[ ${#sources[@]} -gt 0 ]] || { echo "No shell scripts matched .shellcheck-scope" >&2; exit 1; }
+          glob=$(printf '%s\n' "${sources[@]}" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
           echo "glob=${glob}" >> "$GITHUB_OUTPUT"
 
       - name: Validate

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,9 +21,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - name: Resolve shell lint scope
+        id: shell-scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -f .shellcheck-scope ]] || { echo ".shellcheck-scope is missing" >&2; exit 1; }
+          glob=$(sed 's/#.*//' .shellcheck-scope | tr -d '[:blank:]' | grep -v '^$' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+          [[ -n "${glob}" ]] || { echo "No patterns found in .shellcheck-scope" >&2; exit 1; }
+          echo "glob=${glob}" >> "$GITHUB_OUTPUT"
+
       - name: Validate
         uses: projectbluefin/actions/bootc-build/validate-pr@e2ccd51b41d9bb3abd9caeac626fb15c95589c3c # v1
         with:
-          shellcheck-glob: "build/*.sh"
+          shellcheck-glob: ${{ steps.shell-scope.outputs.glob }}
           dockerfile: "Containerfile"
           hadolint-config: ".hadolint.yaml"

--- a/.shellcheck-scope
+++ b/.shellcheck-scope
@@ -2,12 +2,8 @@
 #
 # Consumers:
 #   - Justfile:lint                    (local `just lint`)
-#   - .github/workflows/pr-validation.yml SHOULD resolve this file into the
-#     `shellcheck-glob` input of projectbluefin/actions/bootc-build/validate-pr.
-#     That wiring is NOT yet in place: the hive GitHub App has no `workflows`
-#     permission, so a maintainer must apply it. Until then CI still lints the
-#     narrower hardcoded `build/*.sh` and `just lint` is the only consumer that
-#     honours this manifest. See #324 for the exact workflow patch.
+#   - .github/workflows/pr-validation.yml (resolves this file into the
+#     `shellcheck-glob` input of projectbluefin/actions/bootc-build/validate-pr)
 #   - tests/unit/shellcheck-scope_test.bats, which fails if a tracked *.sh
 #     file matches none of the patterns below
 #

--- a/tests/unit/shellcheck-scope_test.bats
+++ b/tests/unit/shellcheck-scope_test.bats
@@ -86,21 +86,12 @@ tracked_shell_scripts() {
     [[ "$output" == *".github/actions/check-token-health/check_token_health.sh"* ]]
 }
 
-@test "the CI shellcheck-glob is still the known-narrow value (documents the open gap)" {
-    # pr-validation.yml cannot be edited by this change: the hive GitHub App
-    # has no `workflows` permission, so the CI half of #324 must be applied by
-    # a maintainer. This test pins the current value so the follow-up is not
-    # forgotten and so a *different* narrowing cannot slip in unnoticed.
-    #
-    # When a maintainer wires the workflow to .shellcheck-scope, replace this
-    # test with the assertion in the block comment below.
-    #
-    #   run grep -n 'shellcheck-glob' "${WORKFLOW}"
-    #   [ "$status" -eq 0 ]
-    #   [[ "$output" == *'steps.shell-scope.outputs.glob'* ]]
+@test "the CI shellcheck-glob resolves from .shellcheck-scope" {
+    # .github/workflows/pr-validation.yml resolves .shellcheck-scope into
+    # shellcheck-glob via the shell-scope step (see #324).
     run grep -n 'shellcheck-glob:' "${WORKFLOW}"
     [ "$status" -eq 0 ]
-    [[ "$output" == *'"build/*.sh"'* || "$output" == *'steps.shell-scope.outputs.glob'* ]]
+    [[ "$output" == *'steps.shell-scope.outputs.glob'* ]]
 }
 
 @test "Justfile:lint reads the manifest instead of walking the tree" {


### PR DESCRIPTION
## Summary

Wires `.github/workflows/pr-validation.yml` to dynamically resolve the `.shellcheck-scope` manifest into the `shellcheck-glob` input of `bootc-build/validate-pr`. This completes the CI half of #324 that was left unapplied when #326 landed (due to the hive GitHub App lacking `workflows` permissions).

### Changes

1. `.github/workflows/pr-validation.yml`:
   - Adds step `Install just` that fetches a pinned `casey/just` release (`JUST_VERSION`, tracked by Renovate), verifies it against the release `SHA256SUMS`, and installs it. This is a new network fetch in the workflow; it is digest-checked so `check-download-integrity`-style gates are satisfied.
   - Adds step `Resolve shell lint scope` (`id: shell-scope`) that runs `just shell-sources`, the same manifest parser `just lint` uses to read `.shellcheck-scope` (comments and blank lines dropped, only existing files kept), and emits the resulting space-separated file list as `glob` into `$GITHUB_OUTPUT`. The step fails closed if the list is empty. Note the `shellcheck-glob` input therefore receives a pre-expanded file list rather than a glob; `validate-pr` expands it unquoted, which is fine for this repo's paths but would mis-split on a path containing whitespace.
   - Passes `${{ steps.shell-scope.outputs.glob }}` to `validate-pr`'s `shellcheck-glob` input.
2. `.shellcheck-scope`:
   - Updates the header comment to document that `.github/workflows/pr-validation.yml` resolves this file.
3. `tests/unit/shellcheck-scope_test.bats`:
   - Replaces test 6 ("documents the open gap") with the assertion verifying that `shellcheck-glob:` in `pr-validation.yml` resolves from `steps.shell-scope.outputs.glob`.

### Verification

- `bats tests/unit/shellcheck-scope_test.bats` passes (7/7 tests green).
- `actionlint .github/workflows/pr-validation.yml` passes cleanly.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-validation.yml'))"` passes cleanly.
- `just check` passes cleanly.
- Shellcheck verified passing on `.github/actions/check-token-health/check_token_health.sh` and `build/*.sh`.

Fixes #324

— hive: backend=agy
