### PR TITLE
fix(check-token-health): prevent set -e abort on absent rate limit and scope headers

### DIFF
--- a/.github/actions/check-token-health/check_token_health.sh
+++ b/.github/actions/check-token-health/check_token_health.sh
@@ -34,8 +34,8 @@ fi
 echo "Token is valid (HTTP ${HTTP_CODE})."
 
 # Parse rate-limit info
-RATE_REMAINING=$(grep -i "^x-ratelimit-remaining:" "${HEADERS_FILE}" | awk '{print $2}' | tr -d '\r')
-RATE_LIMIT=$(grep -i "^x-ratelimit-limit:" "${HEADERS_FILE}" | awk '{print $2}' | tr -d '\r')
+RATE_REMAINING=$(grep -i "^x-ratelimit-remaining:" "${HEADERS_FILE}" | awk '{print $2}' | tr -d '\r') || true
+RATE_LIMIT=$(grep -i "^x-ratelimit-limit:" "${HEADERS_FILE}" | awk '{print $2}' | tr -d '\r') || true
 echo "Rate limit: ${RATE_REMAINING:-unknown}/${RATE_LIMIT:-unknown}"
 
 if [[ -n "${RATE_REMAINING}" && "${RATE_REMAINING}" -lt "${MIN_REMAINING}" ]]; then
@@ -43,7 +43,7 @@ if [[ -n "${RATE_REMAINING}" && "${RATE_REMAINING}" -lt "${MIN_REMAINING}" ]]; t
 fi
 
 # Check scopes (PATs only — fine-grained tokens don't expose scopes this way)
-SCOPES=$(grep -i "^x-oauth-scopes:" "${HEADERS_FILE}" | sed 's/^x-oauth-scopes:\s*//i' | tr -d '\r')
+SCOPES=$(grep -i "^x-oauth-scopes:" "${HEADERS_FILE}" | sed 's/^x-oauth-scopes:\s*//i' | tr -d '\r') || true
 EXPIRES_AT=""
 
 if [[ -n "${SCOPES}" ]]; then

--- a/.github/actions/check-token-health/check_token_health.sh
+++ b/.github/actions/check-token-health/check_token_health.sh
@@ -34,8 +34,8 @@ fi
 echo "Token is valid (HTTP ${HTTP_CODE})."
 
 # Parse rate-limit info
-RATE_REMAINING=$(grep -i "^x-ratelimit-remaining:" "${HEADERS_FILE}" | awk '{print $2}' | tr -d '\r') || true
-RATE_LIMIT=$(grep -i "^x-ratelimit-limit:" "${HEADERS_FILE}" | awk '{print $2}' | tr -d '\r') || true
+RATE_REMAINING=$({ grep -i "^x-ratelimit-remaining:" "${HEADERS_FILE}" || true; } | awk '{print $2}' | tr -d '\r')
+RATE_LIMIT=$({ grep -i "^x-ratelimit-limit:" "${HEADERS_FILE}" || true; } | awk '{print $2}' | tr -d '\r')
 echo "Rate limit: ${RATE_REMAINING:-unknown}/${RATE_LIMIT:-unknown}"
 
 if [[ -n "${RATE_REMAINING}" && "${RATE_REMAINING}" -lt "${MIN_REMAINING}" ]]; then
@@ -43,7 +43,7 @@ if [[ -n "${RATE_REMAINING}" && "${RATE_REMAINING}" -lt "${MIN_REMAINING}" ]]; t
 fi
 
 # Check scopes (PATs only — fine-grained tokens don't expose scopes this way)
-SCOPES=$(grep -i "^x-oauth-scopes:" "${HEADERS_FILE}" | sed 's/^x-oauth-scopes:\s*//i' | tr -d '\r') || true
+SCOPES=$({ grep -i "^x-oauth-scopes:" "${HEADERS_FILE}" || true; } | sed 's/^x-oauth-scopes:\s*//i' | tr -d '\r')
 EXPIRES_AT=""
 
 if [[ -n "${SCOPES}" ]]; then

--- a/tests/unit/check-token-health_test.bats
+++ b/tests/unit/check-token-health_test.bats
@@ -63,8 +63,6 @@ teardown() {
 }
 
 # A classic PAT response: GitHub returns rate-limit AND x-oauth-scopes headers.
-# Every header the script greps must be present, because `set -e` aborts the
-# script on the first grep that finds nothing (see the two skipped tests below).
 pat_headers() {
     printf 'HTTP/2 200\r\nx-ratelimit-limit: 5000\r\nx-ratelimit-remaining: 4999\r\nx-oauth-scopes: repo, workflow, read:org\r\n'
 }
@@ -160,7 +158,6 @@ pat_headers() {
 }
 
 @test "missing rate limit headers report unknown and still pass" {
-    skip "known defect #339: RATE_REMAINING=\$(grep ...) aborts under set -e when the header is absent"
     STUB_HEADERS="$(printf 'HTTP/2 200\r\n')"
     run bash "${SCRIPT}"
     [ "${status}" -eq 0 ]
@@ -234,7 +231,6 @@ pat_headers() {
 }
 
 @test "fine-grained token without a scopes header skips the scope check" {
-    skip "known defect #339: SCOPES=\$(grep ...) aborts under set -e, so the documented fine-grained/App-token branch is unreachable"
     REQUIRED_SCOPES="repo,workflow"
     STUB_HEADERS="$(printf 'HTTP/2 200\r\nx-ratelimit-limit: 5000\r\nx-ratelimit-remaining: 4999\r\n')"
     run bash "${SCRIPT}"


### PR DESCRIPTION
## Summary

Fixes #339

Under `set -euo pipefail`, the command substitutions for `RATE_REMAINING`, `RATE_LIMIT`, and `SCOPES` caused `check_token_health.sh` to abort immediately whenever `grep` exited non-zero (i.e., whenever a header was not present in the HTTP response).

Consequences:
1. Fine-grained PATs and GitHub App installation tokens do not return `x-oauth-scopes`, causing the script to exit with code 1 rather than falling back to the intended fine-grained token branch.
2. If rate limit headers were absent, the script would also exit 1.
3. Outputs (`valid`, `rate_remaining`, `expires_at`) were never written to `GITHUB_OUTPUT` on those paths.

This PR adds `|| true` to the three command substitutions so that absent headers evaluate cleanly to empty strings, allowing:
- Rate limit headers to fall back to `unknown/unknown`.
- Missing `x-oauth-scopes` to hit the "No OAuth scopes header (likely a fine-grained token — skipping scope check)" path and pass validation.
- All outputs to be written as expected.

Also unskips the two regression test cases in `tests/unit/check-token-health_test.bats` covering absent rate limit headers and fine-grained tokens without scopes.

## Verification

- Ran `bats tests/unit/check-token-health_test.bats`: 24/24 passing, 0 skipped, 0 failing.
- Ran shellcheck on `check_token_health.sh`: clean (0 errors/warnings).
- Ran shfmt formatting check: matches repository standard.

— hive: backend=agy