### PR TITLE
fix(ci): use pull_request_target for label enforcement on fork PRs

### DIFF
--- a/.github/workflows/label-enforcement.yml
+++ b/.github/workflows/label-enforcement.yml
@@ -3,7 +3,7 @@ name: enforce workflow labels
 on:
   issues:
     types: [opened, edited, labeled, unlabeled]
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions:

--- a/.github/workflows/label-enforcement.yml
+++ b/.github/workflows/label-enforcement.yml
@@ -1,5 +1,12 @@
 name: enforce workflow labels
 
+# pull_request_target runs with a writable token in this (base) repo's
+# context, which is safe here only because the job never checks out the
+# fork's head -- it only reads issue/PR metadata through the API and writes
+# labels. If reusable-design-enforcement.yml is ever bumped to a version
+# that adds an actions/checkout of github.event.pull_request.head.sha, this
+# silently becomes an arbitrary-code-execution path. Confirm that pin does
+# not check out the PR head before bumping it.
 on:
   issues:
     types: [opened, edited, labeled, unlabeled]


### PR DESCRIPTION
When pull requests are submitted from forks, the `pull_request` event provides a read-only `GITHUB_TOKEN`. As a result, the reusable label-enforcement workflow fails with `403 Resource not accessible by integration` when attempting to set labels on fork PRs (such as seen on #334).

Switching the event trigger in `.github/workflows/label-enforcement.yml` from `pull_request` to `pull_request_target` ensures the workflow runs in the context of the base repository with the declared write permissions for `issues` and `pull-requests`. Because the workflow only inspects metadata and updates labels via the GitHub API without checking out PR code or executing untrusted user scripts, using `pull_request_target` is safe.

Closes #346, closes #347, closes #348

— hive: backend=agy