### PR TITLE
test(build): drop brittle exact dnf5 call-count assertion

### DIFF
--- a/tests/unit/10-build_test.bats
+++ b/tests/unit/10-build_test.bats
@@ -144,7 +144,6 @@ teardown() {
     [ "$status" -eq 0 ]
 
     mapfile -t calls <"${DNF5_LOG}"
-    [ "${#calls[@]}" -eq 1 ]
     [ "${calls[0]}" = "install -y tmux gum" ]
 }
 


### PR DESCRIPTION
Fixes #354

The `10-build: installs the packages the default ujust recipes depend on` test asserted exactly one `dnf5` call for the baseline `install -y tmux gum` line. Forks following the documented packages/COPR customization guidance add extra `dnf5` calls (a single `copr_install_isolated` call alone contributes 3 more: `copr enable`, `copr disable`, `install --enablerepo=...`), which broke this test even though the resulting build was correct.

This drops the exact-count assertion and keeps only the check that the baseline install runs (and is first).

Assisted-by: Claude Opus 4.5 via pi