### PR TITLE
iso: use signed ostree transport for bootc switch at install time

### DIFF
--- a/iso/iso.toml
+++ b/iso/iso.toml
@@ -11,7 +11,7 @@ contents = """
 # FORK NOTE: change this ref to ghcr.io/<your-org>/<your-repo>:stable —
 # it must match the package that build-image.yml publishes, which is
 # ghcr.io/<repository_owner>/<repository_name>.
-bootc switch --mutate-in-place --transport registry ghcr.io/projectbluefin/finpilot:stable
+bootc switch --mutate-in-place ostree-image-signed:docker://ghcr.io/projectbluefin/finpilot:stable # ponytail: signed transport (cosign/Fulcio/Rekor), matches 00-image-info.sh; drops unsigned --transport registry
 %end
 """
 


### PR DESCRIPTION
## Finding

[sec-check] #330: the ISO kickstart used

```
bootc switch --mutate-in-place --transport registry ghcr.io/projectbluefin/finpilot:stable
```

Plain `registry` (docker://) transport performs **no sigstore/cosign verification** and resolves the mutable `:stable` tag at install time. This is the only install path that skips signature checks, inconsistent with the repo's trust model (`build-image.yml` signs keyless via Fulcio; `promote-main-to-stable.yml` cosign-verifies before promotion; `build/00-image-info.sh` sets `IMAGE_REF="ostree-image-signed:docker://..."`).

## Fix

Switch to the signed OSTree transport, matching `00-image-info.sh`:

```
bootc switch --mutate-in-place ostree-image-signed:docker://ghcr.io/projectbluefin/finpilot:stable
```

Dropping `--transport registry`, `ostree-image-signed:docker://` wraps the registry transport with sigstore verification against Fulcio/Rekor, so the ISO install path verifies the same signed image as in-place upgrades.

— hive: backend=pi model=lemonade/Ornith-1.5-35B-A3B-GGUF-Q6_K